### PR TITLE
cleaned up split_name, addressed #29, added tests

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,0 +1,36 @@
+import re
+
+class Phage:
+  supported_databases = {
+    # European Nucleotide Archive phage database
+    "ENA": "^gi\|[0-9]+\|ref\|([^\|]+)\|\ ([^,]+)[^$]*$",
+
+    # National Center for Biotechnology Information phage database
+    "NCBI": "^ENA\|([^\|]+)\|[^\ ]+\ ([^,]+)[^$]*$",
+
+    # Actinobacteriophage Database
+    "AD": "^([^\ ]+)\ [^,]*,[^,]*,\ Cluster\ ([^$]+)$"
+  }
+  
+
+  def __init__(self, raw_text, phage_finder):
+    self.raw = raw_text.strip()
+    self.refseq = None
+    self.name = None
+    self.db = None
+    self._parsePhage(raw_text, phage_finder)
+
+
+  def _parsePhage(self, raw_text, phage_finder):
+    for db, regex in Phage.supported_databases.items():
+      match = re.search(regex, raw_text)
+      if match is not None:
+        if db is not "AD":
+          self.name = match.group(2)
+          self.refseq = match.group(1)
+        else:
+          short_name = match.group(1)
+          cluster = match.group(2)
+          self.name = "Mycobacteriophage " + short_name
+          self.refseq = phage_finder.findByPhage(short_name, cluster)
+        self.db = db

--- a/test_models.py
+++ b/test_models.py
@@ -1,0 +1,30 @@
+import unittest
+from models import Phage
+from parsers.find_accession import PhageFinder
+
+class TestPhage(unittest.TestCase):
+    
+  phage_finder = PhageFinder('data/PhagesDB_Data.txt')
+
+  def test_ena(self):
+    ena1 = "ENA|AP013478|AP013478.1 Uncultured Mediterranean phage uvMED DNA, complete"
+    ena1_phage = Phage(ena1, TestPhage.phage_finder)
+    self.assertEqual("AP013478", ena1_phage.refseq)
+    self.assertEqual("Uncultured Mediterranean phage uvMED DNA", ena1_phage.name)
+
+
+  def test_ncbi(self):
+    ncbi1 = "gi|526118413|ref|NC_021856.1| Bacillus phage phiNIT1 DNA, complete genome"
+    ncbi1_phage = Phage(ncbi1, TestPhage.phage_finder)
+    self.assertEqual("NC_021856.1", ncbi1_phage.refseq)
+    self.assertEqual("Bacillus phage phiNIT1 DNA", ncbi1_phage.name)
+
+  def test_ad(self):
+    ad1 = "JoeDirt Final Sequence, 74914 bp including 10 bp 3' overhang (TCGAACGGCC), Cluster L1"
+    ad1_phage = Phage(ad1, TestPhage.phage_finder)
+    self.assertEqual("JF704108", ad1_phage.refseq)
+    self.assertEqual("Mycobacteriophage JoeDirt", ad1_phage.name)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
- "sorted" directory now gets added automatically, instead of causing an error
- split_name is now a bit easier to read and makes use of Phage model
- Phage class can take a header string and create a shiny new "Phage" object
   - right now this just conserves refseq, name, and db type (keeping current functionality)
   - these regexes could easily be tweaked and have more groups, etc. to parse/store more info
   - adding a new database type / parsing grammar should be easy
- Added test to prove correctness (just run python test_models.py)

#29 


If you have any issues, let me know. I modeled this from your description and the current functionality, so, for example, I parsed the header strings the same way you had previously.

For the NCBI database did you want to use the first refseq (AA000000) vs. the second? (AA000000.1) - I assumed you did, as this was the current functionality, this could easily be changed by swapping the grouping in the regex.