### PR TITLE
Gitignore python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,106 @@
+##GITHUB PYTHON GITIGNORE START
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+##GITHUB PYTHON GITIGNORE END
 *.pyc
 /.idea/*
 output/*
@@ -7,4 +110,8 @@ pep8_report.txt
 *vsdx
 # front-end dependencies
 visualization/components/
+# os related files
 **.DS_STORE
+# django build specific files
+**.sqlite3
+phageAPI/restapi/migrations/


### PR DESCRIPTION
PR adds Github's recommended [gitignore](https://github.com/github/gitignore/blob/master/Python.gitignore) for python to the repository's original gitignore. Also adds the django sqlite database and its related migration folder to the gitignore. 