### PR TITLE
Adds a default pagination limit of 10 for faster queries.

### DIFF
--- a/phageAPI/phageAPI/settings.py
+++ b/phageAPI/phageAPI/settings.py
@@ -121,3 +121,9 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# Settings for restapi app
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 10
+}


### PR DESCRIPTION
A small addition for limiting default queries to 10 for faster responses. Before the fix the api would return all of the models in the db for a query which took a large amount of time for a populated database.