### PR TITLE
Adds dynamic-rest library implementation

### DIFF
--- a/phageAPI/phageAPI/settings.py
+++ b/phageAPI/phageAPI/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'dynamic_rest',
     'restapi.apps.RestapiConfig'
 ]
 
@@ -123,7 +124,12 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 # Settings for restapi app
-REST_FRAMEWORK = {
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-    'PAGE_SIZE': 10
+# REST_FRAMEWORK = {
+#     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+#     'PAGE_SIZE': 10
+# }
+DYNAMIC_REST = {
+    'ENABLE_LINKS':True,
+    'PAGE_SIZE': 500,
+    'ENABLE_HOST_RELATIVE_LINKS': True
 }

--- a/phageAPI/phageAPI/urls.py
+++ b/phageAPI/phageAPI/urls.py
@@ -17,8 +17,9 @@ from django.conf.urls import url, include
 from django.contrib import admin
 
 from rest_framework import routers
+from dynamic_rest.routers import DynamicRouter
 from restapi import views
-router = routers.DefaultRouter()
+router = DynamicRouter()
 router.register(r'spacers', views.SpacerViewSet)
 router.register(r'repeats', views.RepeatViewSet)
 router.register(r'organisms', views.OrganismViewSet)

--- a/phageAPI/restapi/views.py
+++ b/phageAPI/restapi/views.py
@@ -2,9 +2,9 @@ from django.shortcuts import render
 from rest_framework import viewsets
 from restapi.serializers import SpacerSerializer, RepeatSerializer, OrganismSerializer, OSRPairSerializer
 from restapi.models import Spacer, Repeat, Organism, OrganismSpacerRepeatPair
+from dynamic_rest.viewsets import DynamicModelViewSet
 
-
-class SpacerViewSet(viewsets.ModelViewSet):
+class SpacerViewSet(DynamicModelViewSet):
     """
     API endpoint that allows spacers to be viewed or edited.
     """
@@ -12,7 +12,7 @@ class SpacerViewSet(viewsets.ModelViewSet):
     serializer_class = SpacerSerializer
 
 
-class RepeatViewSet(viewsets.ModelViewSet):
+class RepeatViewSet(DynamicModelViewSet):
     """
     API endpoint that allows repeats to be viewed or edited.
     """
@@ -20,29 +20,16 @@ class RepeatViewSet(viewsets.ModelViewSet):
     serializer_class = RepeatSerializer
 
 
-class OrganismViewSet(viewsets.ModelViewSet):
+class OrganismViewSet(DynamicModelViewSet):
     """
     API endpoint that allows organisms to be viewed or edited.
     """
     queryset = Organism.objects.all()
     serializer_class = OrganismSerializer
 
-    def get_queryset(self):
-        """
-        Optionally restricts the returned organisms to a given accession,
-        by filtering against a `accession` query parameter in the URL.
-        """
-        queryset = Organism.objects.all()
-        accession = self.request.query_params.get('accession', None)
-        name = self.request.query_params.get('name', None)
-        if accession is not None:
-            queryset = queryset.filter(accession=accession)
-        if name is not None:
-            queryset = queryset.filter(name=name)
-        return queryset
 
 
-class OSRPairViewSet(viewsets.ModelViewSet):
+class OSRPairViewSet(DynamicModelViewSet):
     """
     API endpoint that allows repeats to be viewed or edited.
     """


### PR DESCRIPTION
PR adds support for modifying requested fields on an object by using dynamic-rest library default queries. It also adds filtering for models with DRF query syntax. Also modifies the paging system of the api so that it uses pages as a cursor instead of an object offset.