### PR TITLE
Adding Travis-CI support for Django testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - 3.4
     - 3.5
     - 3.6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ python:
     - 3.6
 
 
-install: true
-
 script: python phageAPI/manage.py test restapi
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 
 install: true
 
-script: python phageAPI/manage.py test
+script: python phageAPI/manage.py test restapi
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+    - 3.4
+    - 3.5
+    - 3.6
+
+
+install: true
+
+script: python phageAPI/manage.py test
+
+sudo: false
+

--- a/phageAPI/restapi/tests.py
+++ b/phageAPI/restapi/tests.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 # Create your tests here.
-from models import Organism,  Repeat, Spacer
+from restapi.models import Organism,  Repeat, Spacer
 
 class OrganismTestCase(TestCase):
     """This class contains a test suite for the Organism model."""


### PR DESCRIPTION
Fixes #159 by running tests that are available in restapi/tests.py with using Travis-CI.