### PR TITLE
Add casprotein model and update endpoints

### DIFF
--- a/phageAPI/phageAPI/urls.py
+++ b/phageAPI/phageAPI/urls.py
@@ -16,7 +16,6 @@ Including another URLconf
 from django.conf.urls import url, include
 from django.contrib import admin
 
-from rest_framework import routers
 from dynamic_rest.routers import DynamicRouter
 from restapi import views
 router = DynamicRouter()
@@ -24,6 +23,8 @@ router.register(r'spacers', views.SpacerViewSet)
 router.register(r'repeats', views.RepeatViewSet)
 router.register(r'organisms', views.OrganismViewSet)
 router.register(r'osrpairs', views.OSRPairViewSet)
+router.register(r'casproteins', views.CasProteinViewSet)
+router.register(r'ocpairs', views.OCPairViewSet)
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/phageAPI/restapi/models.py
+++ b/phageAPI/restapi/models.py
@@ -24,6 +24,18 @@ class Organism(models.Model):
         return self.name
 
 
+class Phage(models.Model):
+    accession = models.CharField(max_length=50, blank=True, default='')
+
+
+class CasProtein(models.Model):
+    profileID = models.CharField(max_length=50, blank=True, default='')
+    function = models.CharField(max_length=50, blank=True, default='')
+    gene = models.CharField(max_length=50, blank=True, default='')
+    group = models.CharField(max_length=50, blank=True, default='')
+    type_specificity = models.CharField(max_length=50, blank=True, default='')
+
+
 class OrganismSpacerRepeatPair(models.Model):
     # Has 1 organism and a spacerrepeatpair list with start and end values for
     # locus
@@ -43,10 +55,6 @@ class OrganismAntiCRISPRPair(models.Model):
     genomic_end = models.PositiveIntegerField(default=0)
 
 
-class Phage(models.Model):
-    accession = models.CharField(max_length=50, blank=True, default='')
-
-
 class PhageAntiCRISPRPair(models.Model):
     phage = models.ForeignKey(Phage, on_delete=models.CASCADE, null=True)
     antiCRISPR = models.ForeignKey(
@@ -62,14 +70,11 @@ class PhageSpacerPair(models.Model):
     genomic_end = models.PositiveIntegerField(default=0)
 
 
-class OrganismCas(models.Model):
-    # Has 1 organism and a spacerrepeatpair list with start and end values for
-    # locus
-    organism_id = models.ForeignKey(Organism, on_delete=models.CASCADE, null=True)
-    accession = models.CharField(max_length=50, blank=True, default='')
-    gene_id = models.ForeignKey(Repeat, on_delete=models.CASCADE, null=True)
+class OrganismCasPair(models.Model):
+    organism = models.ForeignKey(
+        Organism, on_delete=models.CASCADE, null=True)
+    casprotein = models.ForeignKey(
+        CasProtein, on_delete=models.CASCADE, null=True)
     genomic_start = models.PositiveIntegerField(default=0)
     genomic_end = models.PositiveIntegerField(default=0)
     evalue = models.PositiveIntegerField(default=0)
-
-

--- a/phageAPI/restapi/serializers.py
+++ b/phageAPI/restapi/serializers.py
@@ -1,5 +1,4 @@
-from restapi.models import Spacer, Repeat, Organism, OrganismSpacerRepeatPair, OrganismCas
-from rest_framework import serializers
+from restapi.models import Spacer, Repeat, Organism, OrganismSpacerRepeatPair, CasProtein, OrganismCasPair
 from dynamic_rest.serializers import DynamicModelSerializer, DynamicRelationField
 from dynamic_rest.fields import DynamicComputedField
 
@@ -38,10 +37,17 @@ class OrganismSerializer(DynamicModelSerializer):
         fields = ('id', 'name', 'accession')
 
 
-class OrganismCasSerializer(DynamicModelSerializer):
+class OCPairSerializer(DynamicModelSerializer):
     class Meta:
-        model = OrganismCas
-        fields = ('organism_id', 'accession')
+        model = OrganismCasPair
+        fields = ('organism', 'casprotein',
+                  'genomic_start', 'genomic_end', 'evalue')
+
+
+class CasProteinSerializer(DynamicModelSerializer):
+    class Meta:
+        model = CasProtein
+        fields = ('profileID', 'function', 'gene', 'group', 'type_specificity')
 
 
 class OSRPairSerializer(DynamicModelSerializer):

--- a/phageAPI/restapi/views.py
+++ b/phageAPI/restapi/views.py
@@ -1,8 +1,7 @@
-from django.shortcuts import render
-from rest_framework import viewsets
-from restapi.serializers import SpacerSerializer, RepeatSerializer, OrganismSerializer, OSRPairSerializer, OrganismCasSerializer
-from restapi.models import Spacer, Repeat, Organism, OrganismSpacerRepeatPair, OrganismCas
+from restapi.serializers import SpacerSerializer, RepeatSerializer, OrganismSerializer, OSRPairSerializer, OCPairSerializer, CasProteinSerializer
+from restapi.models import Spacer, Repeat, Organism, OrganismSpacerRepeatPair, OrganismCasPair, CasProtein
 from dynamic_rest.viewsets import DynamicModelViewSet
+
 
 class SpacerViewSet(DynamicModelViewSet):
     """
@@ -28,17 +27,25 @@ class OrganismViewSet(DynamicModelViewSet):
     serializer_class = OrganismSerializer
 
 
-class OrganismCasViewSet(DynamicModelViewSet):
+class CasProteinViewSet(DynamicModelViewSet):
     """
-    API endpoint that allows spacers to be viewed or edited.
+    API endpoint that allows cas proteins to be viewed or edited.
     """
-    queryset = OrganismCas.objects.all()
-    serializer_class = OrganismCasSerializer
+    queryset = CasProtein.objects.all()
+    serializer_class = CasProteinSerializer
+
+
+class OCPairViewSet(DynamicModelViewSet):
+    """
+    API endpoint that allows organism cas pairs to be viewed or edited.
+    """
+    queryset = OrganismCasPair.objects.all()
+    serializer_class = OCPairSerializer
 
 
 class OSRPairViewSet(DynamicModelViewSet):
     """
-    API endpoint that allows repeats to be viewed or edited.
+    API endpoint that allows organism spacer repeat pairs to be viewed or edited.
     """
     queryset = OrganismSpacerRepeatPair.objects.all()
     serializer_class = OSRPairSerializer


### PR DESCRIPTION
PR splits OrganismCas model into two and renames the former model into OrganismCasPair for consistency and also adds casprotein model for storing model profile ids and type specific attributes.