### PR TITLE
Extracts spacer and repeat sequences of pairs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/phageAPI/lib/crispr_sequence.py
+++ b/phageAPI/lib/crispr_sequence.py
@@ -1,0 +1,32 @@
+from restapi.models import Organism, Spacer, Repeat, OrganismSpacerRepeatPair
+
+class CRISPRSequence(object):
+    """Turns a accession number into an object containing the sequences, in order,
+    of the spacers and repeats
+    """
+
+    def __init__(self, acc):
+        self.accession_id = acc
+        self.organism = Organism.objects.get(accession=self.accession_id)
+        self.pairs = OrganismSpacerRepeatPair.objects.filter(organism_id=self.organism.id).order_by('order')
+
+    def pair_sequence(self, pair):
+        spacer_seq = self.get_spacer_sequence(pair.spacer)
+        repeat_seq = self.get_repeat_sequence(pair.repeat)
+        return {'spacer': spacer_seq, 'repeat': repeat_seq }
+
+    def get_spacer_sequence(self, spacer):
+        spacer = Spacer.objects.get(id=spacer.id)
+        return spacer.sequence
+
+    def get_repeat_sequence(self, repeat):
+        repeat = Repeat.objects.get(id=repeat.id)
+        return repeat.sequence
+
+    def sequences(self):
+        seq = {'spacers': [], 'repeats': []}
+        for pair in self.pairs:
+            seq['repeats'].append(self.pair_sequence(pair)['repeat'])
+            seq['spacers'].append(self.pair_sequence(pair)['spacer'])
+        return seq
+


### PR DESCRIPTION
Suggested by #166.

...by organism accession number.

Uses the ORM to pull data out of the db and returns a hash of two arrays (`spacers` and `repeats`) in order. Doesn't measure total pair size vs. genomic length on account not not being sure what to do if there were multiple loci.

Usable in scripts like so:
```
from lib import crispr_sequence
crispr = crispr_sequence.CRISPRSequence("NZ_CP015726")
crispr.sequences()

{
'repeats': ['GTCCTCATCAGCCCTGGAGGGTTCGCAAC',
  'GTTGCGACCCCTCCAGGGGTGATGACGAC',
  ...
  'GTCCTCATCAGCCCTGGAGGGTTCGCAAC'],

 'spacers': ['ATCACCAAGACGACCCCGCCGGTCCAGCTTGTGACGC',
  'GTGGAGGGGCCAAACCTTCGGCCGCCAGCCCATCGC',
  ...
  'CAGGGGAACGGGACGGGGACGTGGCAGTACTCCG']
}
```