### PR TITLE
Updates anticrispr sequence length to greater than 255 max.

### DIFF
--- a/restapi/models.py
+++ b/restapi/models.py
@@ -12,7 +12,7 @@ class Repeat(models.Model):
 
 
 class AntiCRISPR(models.Model):
-    sequence = models.CharField(max_length=255, blank=True, default='')
+    sequence = models.CharField(max_length=512, blank=True, default='')
     accession = models.CharField(max_length=32, blank=True, default='')
 
 


### PR DESCRIPTION
While adding the anticrisprs, there was one sequence with length 270 that exceeded the maximum sequence length, this change fixes the issue.