### PR TITLE
change format of outfmt argument to fix error and add example usage

### DIFF
--- a/parserscripts/blast.py
+++ b/parserscripts/blast.py
@@ -43,7 +43,7 @@ parser.add_argument('-p', '--penalty', type=int,
 
 args = parser.parse_args()
 task = args.task
-outfmt = '-outfmt 5'
+outfmt = '-outfmt=5'
 
 # initialize command line
 cline = [task, outfmt]

--- a/parserscripts/blast.py
+++ b/parserscripts/blast.py
@@ -1,6 +1,8 @@
 """
 usage - python blast.py [options]
 
+Example usage - python blast.py -t blastn -q data/spacers/NC_000853.fasta -s data/NC_000853.fasta -e 10 -o blast_test.xml
+
 Performs input blast and writes results in xml format.
 
 Options for -t: blastn, blastp, tblastn, blastx, tblastx, psiblast


### PR DESCRIPTION
When I tried to run this script as follows, I got an error on the `outfmt` argument. Adding this `=` sign seemed to fix it. @aays, if it was just an input error, feel free to not merge this.

```
python parserscripts/blast.py -t blastn -q data/spacers/NC_000853.fasta -s data/NC_000853.fasta -e 10 -o blast_test.xml
```