### PR TITLE
PEP8 fixes

### DIFF
--- a/parserscripts/acc2gb.py
+++ b/parserscripts/acc2gb.py
@@ -26,7 +26,7 @@ def main():
             EXAMPLE:
 
             cat data/antiCRISPR_accessions.txt | \
-            python acc2gb.py your@email.com protein fasta > outfile.txt
+                python acc2gb.py your@email.com protein fasta > outfile.txt
 
             Case 1: rettype = gbwithparts, db = nuccore - downloads
                 genbank file with metadata and fasta DNA sequence

--- a/parserscripts/acc2gb.py
+++ b/parserscripts/acc2gb.py
@@ -7,9 +7,10 @@ DEPENDENCIES:
 Biopython
 """
 
+import argparse
 import sys
 import textwrap
-import argparse
+
 from Bio import Entrez
 
 
@@ -17,27 +18,32 @@ def main():
     parser = argparse.ArgumentParser(
         usage='cat INPUT | python acc2gb.py EMAIL DB RETTYPE > OUTPUT',
         description=textwrap.dedent("""\
-            The input file should contain accession IDs to download, one per
-            line.  "Comments" beginning with '#' will be skipped -- this can be
-            useful to include the source of the accession numbers.
+            The input file should contain accession IDs to download,
+            one per line.  "Comments" beginning with '#' will be
+            skipped -- this can be useful to include the source of the
+            accession numbers.
 
             EXAMPLE:
 
-            cat data/antiCRISPR_accessions.txt | python acc2gb.py your@email.com protein fasta > outfile.txt
+            cat data/antiCRISPR_accessions.txt | \
+            python acc2gb.py your@email.com protein fasta > outfile.txt
 
-            Case 1: rettype = gbwithparts, db = nuccore - downloads genbank
-                file with metadata and fasta DNA sequence (i.e. for downloading
-                bacterial genomes with metadata)
+            Case 1: rettype = gbwithparts, db = nuccore - downloads
+                genbank file with metadata and fasta DNA sequence
+                (i.e. for downloading bacterial genomes with metadata)
 
-            Case 2: rettype = fasta, db = protein - downloads fasta file with
-                protein sequence (i.e. for downloading antiCRISPR protein sequences
-                for BLAST)
+            Case 2: rettype = fasta, db = protein - downloads fasta
+                file with protein sequence (i.e. for downloading
+                antiCRISPR protein sequences for BLAST)
             """),
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument('email', nargs=1,
-                        help='your email address (does not need to be registered, just used to identify you)')
+                        help='your email address (does not need to be '
+                             'registered, just used to identify you)')
     parser.add_argument('db', nargs=1,
-                        help='the NCBI database ID, which must be a valid Entrez database name')
+                        help='the NCBI database ID, which must be a '
+                             'valid Entrez database name')
     parser.add_argument('rettype', nargs=1,
                         help='the type of file to retrieve')
     args = parser.parse_args()
@@ -45,14 +51,23 @@ def main():
     Entrez.email = args.email
 
     # get accession numbers out of stdin
-    accs = [l for l in (l.strip() for l in sys.stdin) if l and not l.startswith('#')]
+    accs = [l for l in (l.strip() for l in sys.stdin)
+            if l and not l.startswith('#')]
 
     # fetch
-    sys.stderr.write("Fetching %s entries from GenBank: %s\n" % (len(accs), ", ".join(accs[:10])))
+    sys.stderr.write("Fetching %s entries from GenBank: %s\n" % (
+        len(accs),
+        ", ".join(accs[:10])
+    ))
     for i, acc in enumerate(accs):
         try:
             sys.stderr.write(" %9i %s          \r" % (i + 1, acc))
-            handle = Entrez.efetch(db=args.db, rettype=args.rettype, retmode="text", id=acc)
+            handle = Entrez.efetch(
+                db=args.db,
+                rettype=args.rettype,
+                retmode="text",
+                id=acc
+            )
             # print output to stdout
             sys.stdout.write(handle.read())
         except Exception:

--- a/parserscripts/addRepeatAndSpacersToDB.py
+++ b/parserscripts/addRepeatAndSpacersToDB.py
@@ -1,66 +1,73 @@
 #!/usr/bin/python
 import sqlite3
 
-# THIS file will parse in two files named 'DRdatabase' and 'Spacerdatabase', 
+
+# THIS file will parse in two files named 'DRdatabase' and 'Spacerdatabase',
 # and populate the 'crispr.sqlite' file tables Spacers and Repeats, as per 
 # ISSUE #99 https://github.com/goyalsid/phageParser/issues/99
 
-def readInputFile(filename):
-	fin = open(filename,'r')
-	flines = fin.readlines()
-	fileDict = dict()
-	for f in flines:
-		f = f.replace('\n', '')
-		if(f[0] == '>'):
-			accessions = f[1:].split('|')
-		else:
-			fileDict[f] = accessions
-	return fileDict
-
-def printDict(d):
-	for i in d:
-		print(i, d[i])
-
-def getLargestID(c, name, idName):
-	# NOT USED
-	# SELECT * FROM Spacer ORDER BY SpacerID DESC LIMIT 1
-	q = "SELECT * FROM " + name + " ORDER BY " + idName + " DESC LIMIT 1"
-	c.execute(q)
-	return c.fetchone()[0]
-
-def SQL_add(elem, name, dbName):
-	conn = sqlite3.connect(dbName)
-	c = conn.cursor()
-	colName = name+'Sequence'
-	q = "INSERT INTO " + str(name) + " ("  + str(colName) + ") VALUES ('"+ elem+"')"
-	try:
-		c.execute(q)
-		conn.commit()
-	except sqlite3.IntegrityError:
-		print("Already In Database", elem)
-	c.close()
-	conn.close()
-
-def SQL_search(elem, name, column, dbName):
-	conn = sqlite3.connect(dbName)
-	c = conn.cursor()
-	q = "SELECT * FROM " + name + " " + " WHERE " + column + " = '" + elem + "'"
-	# print q
-	c.execute(q)
-	r = c.fetchone()
-	c.close()
-	conn.close()
-	return r
-
-def populateDB(dbName, tableName, fileName):
-	inputDict = readInputFile(fileName)
-	for d in inputDict:
-		SQL_add(d, tableName, dbName)
+def read_input_file(filename):
+    fin = open(filename, 'r')
+    flines = fin.readlines()
+    file_dict = dict()
+    for f in flines:
+        f = f.replace('\n', '')
+        if f[0] == '>':
+            accessions = f[1:].split('|')
+        else:
+            file_dict[f] = accessions
+    return file_dict
 
 
-repeatFile = 'data/DRdatabase.txt'
-spacerFile = 'data/spacerdatabase.txt'
-dbName = 'crispr.sqlite'
+def print_dict(d):
+    for i in d:
+        print(i, d[i])
 
-populateDB(dbName, 'Repeat', repeatFile)
-populateDB(dbName, 'Spacer', spacerFile)
+
+def get_largest_id(c, name, id_name):
+    # NOT USED
+    # SELECT * FROM Spacer ORDER BY SpacerID DESC LIMIT 1
+    q = "SELECT * FROM " + name + " ORDER BY " + id_name + " DESC LIMIT 1"
+    c.execute(q)
+    return c.fetchone()[0]
+
+
+def sql_add(elem, name, db_name):
+    conn = sqlite3.connect(db_name)
+    c = conn.cursor()
+    col_name = name + 'Sequence'
+    q = "INSERT INTO " + str(name) + " (" + str(
+        col_name) + ") VALUES ('" + elem + "')"
+    try:
+        c.execute(q)
+        conn.commit()
+    except sqlite3.IntegrityError:
+        print("Already In Database", elem)
+    c.close()
+    conn.close()
+
+
+def sql_search(elem, name, column, db_name):
+    conn = sqlite3.connect(db_name)
+    c = conn.cursor()
+    q = "SELECT * FROM " + name + "  WHERE " + column + " = '" + elem + "'"
+    # print q
+    c.execute(q)
+    r = c.fetchone()
+    c.close()
+    conn.close()
+    return r
+
+
+def populate_db(db_name, table_name, file_name):
+    input_dict = read_input_file(file_name)
+    for d in input_dict:
+        sql_add(d, table_name, db_name)
+
+
+repeat_file = 'data/DRdatabase.txt'
+spacer_file = 'data/spacerdatabase.txt'
+db_name = 'crispr.sqlite'
+
+populate_db(db_name, 'Repeat', repeat_file)
+populate_db(db_name, 'Spacer', spacer_file)

--- a/parserscripts/addRepeatAndSpacersToDB.py
+++ b/parserscripts/addRepeatAndSpacersToDB.py
@@ -36,8 +36,8 @@ def sql_add(elem, name, db_name):
     conn = sqlite3.connect(db_name)
     c = conn.cursor()
     col_name = name + 'Sequence'
-    q = "INSERT INTO " + str(name) + " (" + str(
-        col_name) + ") VALUES ('" + elem + "')"
+    q = ("INSERT INTO " + str(name) + " (" + str(col_name)
+         + ") VALUES ('" + elem + "')")
     try:
         c.execute(q)
         conn.commit()

--- a/parserscripts/anticrisprblast.py
+++ b/parserscripts/anticrisprblast.py
@@ -7,9 +7,10 @@ Created on Fri Jun  3 15:18:42 2016
 Given a 
 echo <file> | python anticrisprblast.py <genome> > <output>
 where:
-<file> is the name of a fasta file containing protein sequences of the antiCRISPR genes of interest
-<genome> is the name of a file containing the bacterial genome of interest 
-<output> is the name of the (xml) file you'd like to write the results to  
+<file> is the name of a fasta file containing protein sequences of the
+    antiCRISPR genes of interest
+<genome> is the name of a file containing the bacterial genome of interest
+<output> is the name of the (xml) file you'd like to write the results to
 
 http://www.ncbi.nlm.nih.gov/books/NBK279675/ 
 ^ see Table C5 for other tblastn options 
@@ -19,21 +20,27 @@ Biopython
 blast+
 """
 
-from Bio.Blast.Applications import NcbitblastnCommandline 
+import subprocess
 import sys
-import subprocess 
+
+from Bio.Blast.Applications import NcbitblastnCommandline
 
 genome = sys.argv[-1]
 
-#loads input file
+# loads input file
 seq = [l.strip() for l in sys.stdin if l.strip()]
 seq = ''.join(seq)
 
-#builds command line string 
-tblastn_obj = NcbitblastnCommandline(cmd = 'tblastn', query=seq, subject=genome, 
-                                     evalue=10, outfmt = 5)
+# builds command line string
+tblastn_obj = NcbitblastnCommandline(
+    cmd='tblastn',
+    query=seq,
+    subject=genome,
+    evalue=10,
+    outfmt=5
+)
 
-tblastn_cline = str(tblastn_obj) 
+tblastn_cline = str(tblastn_obj)
 
-#executes command line string in bash 
-subprocess.call(tblastn_cline, shell=True) 
+# executes command line string in bash
+subprocess.call(tblastn_cline, shell=True)

--- a/parserscripts/bac_info_parser.py
+++ b/parserscripts/bac_info_parser.py
@@ -1,5 +1,3 @@
-# parse_Genbank.py
-
 from Bio.SeqIO import parse
 
 genbank_file = 'data/Genbank_example.txt'

--- a/parserscripts/bac_info_parser.py
+++ b/parserscripts/bac_info_parser.py
@@ -1,4 +1,4 @@
-#parse_Genbank.py
+# parse_Genbank.py
 
 from Bio.SeqIO import parse
 
@@ -8,7 +8,7 @@ outdict = {}
 
 result_handle = open(genbank_file)
 
-records = parse(result_handle,'genbank')
+records = parse(result_handle, 'genbank')
 
 for x in records:
     try:
@@ -24,5 +24,5 @@ for x in records:
     except:
         print("no taxonomy")
     accs = x.annotations['accessions']
-    
-    outdict[acc] = [org,tax]
+
+    outdict[acc] = [org, tax]

--- a/parserscripts/blast.py
+++ b/parserscripts/blast.py
@@ -15,10 +15,10 @@ Biopython
 blast+
 """
 
-import os
-import sys
 import argparse
+import os
 import subprocess
+import sys
 
 parser = argparse.ArgumentParser(description='General purpose BLAST function.',
                                  usage='blast.py [options]')

--- a/parserscripts/cleanPhages.py
+++ b/parserscripts/cleanPhages.py
@@ -2,13 +2,15 @@ import csv
 import operator
 import os
 
-from phage import Phage
 from parsers.find_accession import PhageFinder
+from phage import Phage
+
 
 def csv_to_list(csv_file, delimiter=","):
-    with open (csv_file, 'r') as csv_con:
+    with open(csv_file, 'r') as csv_con:
         reader = csv.reader(csv_con, delimiter=delimiter)
         return list(reader)
+
 
 def convert_cells_to_floats(csv_cont):
     for row in range(len(csv_cont)):
@@ -18,31 +20,35 @@ def convert_cells_to_floats(csv_cont):
             except ValueError:
                 pass
 
+
 def sort_by_column(csv_cont, col, reverse=False):
     header = csv_cont[0]
     body = csv_cont[1:]
-    if isinstance(col,str):
+    if isinstance(col, str):
         col_index = header.index(col)
     else:
         col_index = col
     body = sorted(body,
                   key=operator.itemgetter(col_index),
                   reverse=reverse)
-    body.insert(0,header)
+    body.insert(0, header)
     return body
+
 
 def get_phagename_and_refseq(row, phage_finder):
     phage = Phage(row, phage_finder)
     return phage.name, phage.refseq
 
+
 def split_name(csv_list, phage_finder):
-    csv_list[0].insert(1,"Accession")
+    csv_list[0].insert(1, "Accession")
     for row in csv_list[1:]:
-        row.insert(1,'')
+        row.insert(1, '')
         name, refseq = get_phagename_and_refseq(row[1], phage_finder)
         if name is not None and refseq is not None:
             row[1], row[2] = name, refseq
     return csv_list
+
 
 def compare_phages(csv_sorted):
     csv_new = []
@@ -56,11 +62,12 @@ def compare_phages(csv_sorted):
 
 
 def print_csv(csv_content):
-    print (50*'-')
+    print(50 * '-')
     for row in csv_content:
         row = [str(e) for e in row]
-        print ('\t' .join(row))
-    print (50*'_')
+        print('\t'.join(row))
+    print(50 * '_')
+
 
 def write_csv(dest, csv_cont):
     with open(dest, 'w+') as out_file:
@@ -68,22 +75,22 @@ def write_csv(dest, csv_cont):
         for row in csv_cont:
             writer.writerow(row)
 
+
 # -------------------------------------------------------------------
 directory = "output"
 phage_finder = PhageFinder('data/PhagesDB_Data.txt')
 
-sorted_dir = os.path.dirname("%s/" %directory) + "/sorted"
+sorted_dir = os.path.dirname("%s/" % directory) + "/sorted"
 if not os.path.isdir(sorted_dir):
     os.makedirs(sorted_dir)
 
-for fn in os.listdir("%s/" %directory):
+for fn in os.listdir("%s/" % directory):
     if fn == 'sorted':
         continue
-    csv_cont = csv_to_list("%s/%s" %(directory,fn))
+    csv_cont = csv_to_list("%s/%s" % (directory, fn))
     convert_cells_to_floats(csv_cont)
     csv_sorted = sort_by_column(csv_cont, "Expect")
     csv_sorted = split_name(csv_sorted, phage_finder)
     csv_new = compare_phages(csv_sorted)
-    write_csv("%s/sorted/sorted.%s" %(directory,fn), csv_new)
-    #print_csv(csv_sorted)
-
+    write_csv("%s/sorted/sorted.%s" % (directory, fn), csv_new)
+    # print_csv(csv_sorted)

--- a/parserscripts/collect_accessions.py
+++ b/parserscripts/collect_accessions.py
@@ -24,4 +24,4 @@ args = parser.parse_args()
 
 records = pd.read_csv(args.file,sep='\t', header=None)
 records.to_csv(args.o,header=False,sep=',',columns=[1],index=False)
-print('Accession file succesfully written out at:',args.o)
+print('Accession file successfully written out at:',args.o)

--- a/parserscripts/collect_accessions.py
+++ b/parserscripts/collect_accessions.py
@@ -1,27 +1,43 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 Created on Tue Aug 15 11:26:23 2017
-This script processes NCBI data exports (from ftp://ftp.ncbi.nlm.nih.gov/genomes/GENOME_REPORTS/IDS/)
-to extract lists of organism accession IDs, later used for downloading complete genome sequences.
+This script processes NCBI data exports
+(from ftp://ftp.ncbi.nlm.nih.gov/genomes/GENOME_REPORTS/IDS/)
+to extract lists of organism accession IDs, later used for downloading
+complete genome sequences.
 
 @author: mbonsma / thisisjaid
-'''
+"""
 
-import os
-import pandas as pd
 import argparse
 
-parser = argparse.ArgumentParser(add_help=True, description='''phageParser - collect_accessions.py - 
-                                 This script processes NCBI data exports 
-                                 (from ftp://ftp.ncbi.nlm.nih.gov/genomes/GENOME_REPORTS/IDS/)
-                                 to generate lists of organism accession IDs, later used for downloading 
-                                 complete genome sequences''')
-parser.add_argument('-o', metavar='output_file', action='store', type=str, default='accessions.csv', 
-                    help='Full path to results output file (default: accessions.csv)')
-parser.add_argument('file', action='store', help='Full path to NCBI data export file')
+import pandas as pd
+
+parser = argparse.ArgumentParser(
+    add_help=True,
+    description="""\
+phageParser - collect_accessions.py - 
+This script processes NCBI data exports 
+(from ftp://ftp.ncbi.nlm.nih.gov/genomes/GENOME_REPORTS/IDS/)
+to generate lists of organism accession IDs, later used for downloading 
+complete genome sequences"""
+)
+parser.add_argument(
+    '-o',
+    metavar='output_file',
+    action='store',
+    type=str,
+    default='accessions.csv',
+    help='Full path to results output file (default: accessions.csv)'
+)
+parser.add_argument(
+    'file',
+    action='store',
+    help='Full path to NCBI data export file'
+)
 
 args = parser.parse_args()
 
-records = pd.read_csv(args.file,sep='\t', header=None)
-records.to_csv(args.o,header=False,sep=',',columns=[1],index=False)
-print('Accession file successfully written out at:',args.o)
+records = pd.read_csv(args.file, sep='\t', header=None)
+records.to_csv(args.o, header=False, sep=',', columns=[1], index=False)
+print('Accession file successfully written out at:', args.o)

--- a/parserscripts/crispr_db_parser.py
+++ b/parserscripts/crispr_db_parser.py
@@ -4,7 +4,9 @@ Madeleine Bonsma
 March 7, 2015
 Updated May 3, 2016
 
-This script takes a list of spacers downloaded from the CRISPRdb website and splits them into individual files, one file per organism. Result files are saved in "data/spacers".
+This script takes a list of spacers downloaded from the CRISPRdb
+website and splits them into individual files, one file per organism.
+Result files are saved in "data/spacers".
 """
 
 import linecache
@@ -13,8 +15,8 @@ import os
 # CRISPR db parser
 # MB Mar 07 2015
 
-filename = "data/spacerdatabase.txt" # File from CRISPRdb to sort 
-spacer_db = open("%s" %(filename),"r") 
+filename = "data/spacerdatabase.txt"  # File from CRISPRdb to sort
+spacer_db = open("%s" % filename, "r")
 
 # check if directory for saving exists
 directory = "data/spacers"
@@ -25,47 +27,74 @@ if not os.path.exists(directory):
 refseq_list = []
 refseq_dict = {}
 
-for num, line in enumerate(spacer_db,1):
-    check = True # awkward while loop
-    if line[0] == ">": # use the headers, indicated by >, to sort
-        line = line[1:] # delete 1st character to make loop same each time around
+for num, line in enumerate(spacer_db, 1):
+    check = True  # awkward while loop
+    if line[0] == ">":  # use the headers, indicated by >, to sort
+        # delete 1st character to make loop same each time around
+        line = line[1:]
         counter = 0
-        while check == True: 
-            counter +=1
-            refseq = line[0:9] # this part of the header is the NCBI accession#
-            if refseq not in refseq_list: # open new file if it's a new bacteria
-                refseq_dict[refseq] = open("data/spacers/%s.fasta" %(refseq),"w")
-                if "|" in line: # if more than one bacteria contain spacer
+        while check:
+            counter += 1
+            # this part of the header is the NCBI accession
+            refseq = line[0:9]
+            if refseq not in refseq_list:
+                # open new file if it's a new bacteria
+                refseq_dict[refseq] = open(
+                    "data/spacers/%s.fasta" % refseq,
+                    "w"
+                )
+                if "|" in line:
+                    # if more than one bacteria contain spacer
                     i = line.index("|")
-                    writeline = line[10:i]  # include in header the locus identifier and spacer position identifier
-                    writeline2 = writeline.replace('_','.')
-                else: # if it's only one bacteria
-                    writeline = line[10:] 
-                    writeline2 = writeline.replace('_','.')
+                    # include in header the locus identifier and spacer
+                    # position identifier
+                    writeline = line[10:i]
+                    writeline2 = writeline.replace('_', '.')
+                else:
+                    # if it's only one bacteria
+                    writeline = line[10:]
+                    writeline2 = writeline.replace('_', '.')
                 # write header and spacer to file
                 refseq_dict[refseq].write(">" + writeline2 + "\n")
-                refseq_dict[refseq].write(linecache.getline("%s" %(filename), num+1))
-                if counter == 1: # since the file is organized alphabetically by the first bacteria in the header, if we see a different first bacteria we can close the previous file to free up space. This might be buggy. 
+                refseq_dict[refseq].write(
+                    linecache.getline("%s" % filename, num + 1)
+                )
+                # since the file is organized alphabetically by the
+                # first bacteria in the header, if we see a different
+                # first bacteria we can close the previous file to free
+                # up space. This might be buggy.
+                if counter == 1:
                     try:
-                        refseq_prev = linecache.getline("%s" %(filename), num-2)[1:10]
-                        refseq_dict[refseq_prev].close() 
+                        refseq_prev = linecache.getline(
+                            "%s" % filename,
+                            num - 2
+                        )[1:10]
+                        refseq_dict[refseq_prev].close()
                     except:
-                        pass # throws exception on the first time through, otherwise wouldn't
-                refseq_list.append(refseq) 
+                        # throws exception on the first time through,
+                        # otherwise wouldn't
+                        pass
+                refseq_list.append(refseq)
             if refseq in refseq_list:
                 if "|" in line:
                     i = line.index("|")
-                    writeline = line[10:i]  # include in header the locus identifier and spacer position identifier
-                    writeline2 = writeline.replace('_','.')
+                    # include in header the locus identifier and spacer
+                    # position identifier
+                    writeline = line[10:i]
+                    writeline2 = writeline.replace('_', '.')
                 else:
-                    writeline = line[10:] 
-                    writeline2 = writeline.replace('_','.')
-                
+                    writeline = line[10:]
+                    writeline2 = writeline.replace('_', '.')
+
                 refseq_dict[refseq].write(">" + writeline2 + "\n")
-                refseq_dict[refseq].write(linecache.getline("%s" %(filename), num+1))
+                refseq_dict[refseq].write(
+                    linecache.getline("%s" % filename, num + 1)
+                )
             try:
                 i = line.index("|")
-                line = line[i+1:] # change the header so that the next bacteria is up for the loop
+                # change the header so that the next bacteria is up for
+                # the loop
+                line = line[i + 1:]
             except:
                 check = False
 

--- a/parserscripts/crispr_db_parser.py
+++ b/parserscripts/crispr_db_parser.py
@@ -16,7 +16,7 @@ import os
 # MB Mar 07 2015
 
 filename = "data/spacerdatabase.txt"  # File from CRISPRdb to sort
-spacer_db = open("%s" % filename, "r")
+spacer_db = open(filename, "r")
 
 # check if directory for saving exists
 directory = "data/spacers"

--- a/parserscripts/crisprfinder.py
+++ b/parserscripts/crisprfinder.py
@@ -1,29 +1,38 @@
-'''
-Current non-native dependencies in selenium package. If desired to have script run 'headless' (without any browser opening), then need additional python selenium PhantomJS dependency. 
+"""
+Current non-native dependencies in selenium package. If desired to have
+script run 'headless' (without any browser opening), then need
+additional python selenium PhantomJS dependency.
 
 Instructions for headless operation: 
-	- replace 'driver = webdriver.Firefox()' line with 'driver = webdriver.PhantomJS()'
+    - replace 'driver = webdriver.Firefox()' line with
+      'driver = webdriver.PhantomJS()'
 
-Note: accessing the CRISPRfinder tool online for many files back to back may block ip address if website is setup to prevent automated webcrawling. A potential work-around is to add a 'wait' or 'sleep' function in between individual calls (i.e. for 50ms). 
-'''
+Note: accessing the CRISPRfinder tool online for many files back to
+back may block ip address if website is setup to prevent automated
+webcrawling. A potential work-around is to add a 'wait' or 'sleep'
+function in between individual calls (i.e. for 50ms).
+"""
 
-from selenium import webdriver
 import os
 import sys
 
-genome_input = sys.argv[1] #.fasta file format required
-CrisprResults_output = sys.argv[2] #textfile with CRISPR results
-#path of input/output files is relative to python script location
+from selenium import webdriver
+
+genome_input = sys.argv[1]  # .fasta file format required
+crispr_results_output = sys.argv[2]  # textfile with CRISPR results
+# path of input/output files is relative to python script location
 
 driver = webdriver.Firefox()
 driver.get("http://crispr.i2bc.paris-saclay.fr/Server/")
 assert "CRISPR" in driver.title
-driver.find_element_by_name("fname").send_keys(os.getcwd()+'/'+genome_input)
+driver.find_element_by_name("fname").send_keys(
+    os.getcwd() + '/' + genome_input
+)
 driver.find_element_by_name("submit").click()
 
 crispr_results = driver.find_element_by_xpath("//div[@class='content']").text
 
-with open(CrisprResults_output, 'wt') as fHandle:        
-    fHandle.write('\n'.join(crispr_results.split("\n")[3:]))
+with open(crispr_results_output, 'wt') as f_handle:
+    f_handle.write('\n'.join(crispr_results.split("\n")[3:]))
 
 driver.close()

--- a/parserscripts/extract_CRISPRdb.py
+++ b/parserscripts/extract_CRISPRdb.py
@@ -1,15 +1,18 @@
-import requests
-from pattern import web
-import re
 import csv
 import os
+import re
+
+import requests
+from pattern import web
+
 
 def get_dom(url):
     html = requests.get(url).text
     dom = web.Element(html)
     return dom
 
-def get_taxons_from_CRISPRdb():
+
+def get_taxons_from_crispr_db():
     taxon_ids = []
     if os.path.exists('taxon_ids.csv'):
         with open('taxon_ids.csv', 'r') as csvfile:
@@ -21,29 +24,33 @@ def get_taxons_from_CRISPRdb():
     dom_homepage = get_dom(url)
     container = dom_homepage('div[class="strainlist"]')[0]
     for link in container('a'):
-        taxon_id = link.href.encode('ascii','ignore')[46:]
+        taxon_id = link.href.encode('ascii', 'ignore')[46:]
         taxon_ids.append(taxon_id)
         with open('taxon_ids.csv', 'a') as csvfile:
             writer = csv.writer(csvfile)
             writer.writerow([taxon_id])
     return taxon_ids
 
+
 def get_sequences(taxon_id):
-    url = "http://crispr.u-psud.fr/cgi-bin/crispr/SpecieProperties.cgi?Taxon_id=" + taxon_id
+    url = ("http://crispr.u-psud.fr/cgi-bin/crispr/SpecieProperties.cgi?"
+           "Taxon_id=" + taxon_id)
     dom = get_dom(url)
     table = dom('table[class="primary_table"]')[1]
     sequences = []
     for sequence in table('tr'):
-        seq = []
-        if sequence('th')==[]:
-            seq = {}
-            seq['Taxon_id'] = taxon_id
-            seq['RefSeq'] = sequence('td')[1].content.encode('ascii','ignore')
+        if not sequence('th'):
+            seq = {
+                'Taxon_id': taxon_id,
+                'RefSeq': sequence('td')[1].content.encode('ascii', 'ignore')
+            }
             sequences.append(seq)
     return sequences
 
+
 def get_loc_ids(sequence):
-    url = "http://crispr.u-psud.fr/crispr/CRISPRProperties.php?RefSeq=" + sequence['RefSeq']
+    url = ("http://crispr.u-psud.fr/crispr/CRISPRProperties.php?RefSeq="
+           + sequence['RefSeq'])
     dom = get_dom(url)
     div = dom('div[class="rightcontent"]')[1]
     table = div('table[class="primary_table"]')[0]
@@ -51,19 +58,25 @@ def get_loc_ids(sequence):
     loc_ids = []
     for crispr_id in tbody('tr'):
         cell = crispr_id('td')[1]
-        crispr_id_value = cell('font')[0].content.encode('ascii','ignore').replace('<br/n/>','')
-        crispr_id_value = crispr_id_value.replace('\n','')
-        crispr_id_value = crispr_id_value.replace('\t','')
-        crispr_id_value = crispr_id_value.replace('<br />','')
+        crispr_id_value = (cell('font')[0]
+                           .content
+                           .encode('ascii', 'ignore')
+                           .replace('<br/n/>', ''))
+        crispr_id_value = crispr_id_value.replace('\n', '')
+        crispr_id_value = crispr_id_value.replace('\t', '')
+        crispr_id_value = crispr_id_value.replace('<br />', '')
         loc_ids.append(crispr_id_value.split('_')[-1])
     return loc_ids
 
-def get_positions(sequence,loc_id):
-    params = {}
-    params['Taxon'] =  sequence['Taxon_id']
+
+def get_positions(sequence, loc_id):
+    params = {'Taxon': sequence['Taxon_id']}
     crispr_id = sequence['RefSeq'] + "_" + loc_id
     params['checked[]'] = crispr_id
-    r = requests.post("http://crispr.u-psud.fr/crispr/crispr.php", data=params)
+    r = requests.post(
+        "http://crispr.u-psud.fr/crispr/crispr.php",
+        data=params
+    )
     source = web.Element(r.text)
     print("Crispr id: " + crispr_id)
     table = source('table[class="crispr"]')[0]
@@ -73,40 +86,47 @@ def get_positions(sequence,loc_id):
     begin = begin.group(0).split(' ')[-1]
     end = re.search('(?<=</span>) +\d+', td[1].content)
     end = end.group(0).split(' ')[-1]
-    return [begin,end]
+    return [begin, end]
+
 
 def get_results():
     print("Getting taxon ids...")
-    taxon_ids =  get_taxons_from_CRISPRdb()
+    taxon_ids = get_taxons_from_crispr_db()
     n = len(taxon_ids)
     i = 0.
     print("Getting positions...")
     restart = False
     var = False
     if os.path.exists('last'):
-        f = open('last','r')
-        last = f.read()
-        [last_taxon_id,last_refseq,last_loc_id] = last.split(',')
+        with open('last', 'r') as f:
+            last = f.read()
+        [last_taxon_id, last_refseq, last_loc_id] = last.split(',')
         restart = True
     for taxon_id in taxon_ids:
-        print("{:.2%}".format(i/n))
+        print("{:.2%}".format(i / n))
         print("Taxon id: " + taxon_id)
-        if(restart == True and last_taxon_id == taxon_id):
+        if restart and last_taxon_id == taxon_id:
             var = True
             continue
-        if (var == True or restart == False):
+        if var or not restart:
             sequences = get_sequences(taxon_id)
             for sequence in sequences:
                 loc_ids = get_loc_ids(sequence)
                 sequence['Loc_ids'] = loc_ids
                 for loc_id in sequence['Loc_ids']:
-                    [begin,end] = get_positions(sequence,loc_id)
-                    result = [sequence['RefSeq'],loc_id,begin,end]
+                    [begin, end] = get_positions(sequence, loc_id)
+                    result = [sequence['RefSeq'], loc_id, begin, end]
                     with open('results.csv', 'a') as csvfile:
                         writer = csv.writer(csvfile, delimiter=',')
                         writer.writerow(result)
-                    f = open('last','w')
-                    f.write(sequence['Taxon_id'] + "," + sequence['RefSeq'] + "," + loc_id)
+                    with open('last', 'w') as f:
+                        f.write(','.join((
+                            sequence['Taxon_id'],
+                            sequence['RefSeq'],
+                            loc_id
+                        )))
+
         i += 1
+
 
 get_results()

--- a/parserscripts/extract_CRISPRdb.py
+++ b/parserscripts/extract_CRISPRdb.py
@@ -61,10 +61,10 @@ def get_loc_ids(sequence):
         crispr_id_value = (cell('font')[0]
                            .content
                            .encode('ascii', 'ignore')
-                           .replace('<br/n/>', ''))
-        crispr_id_value = crispr_id_value.replace('\n', '')
-        crispr_id_value = crispr_id_value.replace('\t', '')
-        crispr_id_value = crispr_id_value.replace('<br />', '')
+                           .replace('<br/n/>', '')
+                           .replace('\n', '')
+                           .replace('\t', '')
+                           .replace('<br />', ''))
         loc_ids.append(crispr_id_value.split('_')[-1])
     return loc_ids
 

--- a/parserscripts/filter/tests/test_filter_by_expect.py
+++ b/parserscripts/filter/tests/test_filter_by_expect.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -19,6 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
 
 def test_filter():
     # TODO: add tests

--- a/parserscripts/filterByExpect.py
+++ b/parserscripts/filterByExpect.py
@@ -3,17 +3,19 @@
 # for each xml output file, use NCBIXML to extract the important things
 # Note: this requires blast output in xml format (set 'outfmt = 5')
 
-'''
+"""
 USAGE:
 python filterByExpect.py <indir> <outdir>
-'''
+"""
 
 import os
-import csv
 import sys
+
 import pandas as pd
 
-def parse_blast(resultfile):  # takes in the BLAST result, outputs list that can be made into csv
+
+def parse_blast(resultfile):
+    """takes in the BLAST result, outputs list that can be made into csv"""
     from Bio.Blast import NCBIXML
     result_handle = open(resultfile)
     blast_records = NCBIXML.parse(result_handle)
@@ -28,18 +30,18 @@ def parse_blast(resultfile):  # takes in the BLAST result, outputs list that can
     # csv_list.append(header)
     count = 0
     for blast_record in blast_records:
-        '''help(blast_record.alignments[0].hsps[0])'''  # these give help info for the parts
+        # these give help info for the parts
+        '''help(blast_record.alignments[0].hsps[0])'''
         '''help(blast_record.alignments[0])        '''
         count += 1
 
         query = blast_record.query
         for alignment in blast_record.alignments:
-
             name = alignment.title
             length = alignment.length
 
-            # I don't know if we will ever have more than one, so might as well
-            # take the first one.
+            # I don't know if we will ever have more than one, so might
+            # as well take the first one.
             hsp = alignment.hsps[0]
             score = hsp.score
             expect = hsp.expect
@@ -55,7 +57,8 @@ def parse_blast(resultfile):  # takes in the BLAST result, outputs list that can
     return pd.DataFrame(csv_list, columns=header)
 
 
-def write_csv(dest, df):  # takes a list of lists object with each csv row as a list
+def write_csv(dest, df):
+    """takes a list of lists object with each csv row as a list"""
     df.to_csv(dest)
 
 
@@ -64,11 +67,11 @@ def main():
     outdir = str(sys.argv[2])
 
     for fn in os.listdir("%s/" % indir):
-        ID = fn[:fn.index('.')]
+        id_ = fn[:fn.index('.')]
         if fn == 'sorted':
             continue
         csv_list = parse_blast(fn)
-        write_csv("%s/%s.csv" % (outdir, ID), csv_list)
+        write_csv("%s/%s.csv" % (outdir, id_), csv_list)
 
 
 if __name__ == '__main__':

--- a/parserscripts/getAccession.py
+++ b/parserscripts/getAccession.py
@@ -1,10 +1,14 @@
 import time
+
 from parsers.find_accession import PhageFinder
 
 
+def current_milli_time():
+    return int(round(time.time() * 1000))
+
+
 if __name__ == '__main__':
-    current_milli_time = lambda: int(round(time.time() * 1000))
     finder = PhageFinder('data/PhagesDB_Data.txt')
 
-    print(finder.findByPhage('Arbiter', 'B2'))
-    print(finder.findByPhage('Ariel', 'J'))
+    print(finder.find_by_phage('Arbiter', 'B2'))
+    print(finder.find_by_phage('Ariel', 'J'))

--- a/parserscripts/getGenomes.py
+++ b/parserscripts/getGenomes.py
@@ -1,17 +1,17 @@
-from parsers.genome_extractor import GenomeExtractor
 import sys
 
+from parsers.genome_extractor import GenomeExtractor
+
 if __name__ == '__main__':
-    file_name = '' 
+    file_name = ''
     try:
         file_name = sys.argv[1]
     except IOError as e:
         print(e.errno)
         print(e)
     except IndexError:
-        file_name = 'data/NC_020879_phage.gb'  
-
+        file_name = 'data/NC_020879_phage.gb'
 
     gext = GenomeExtractor(file_name)
 
-    print(gext.findNeighbours(181, 240, 60, 60))
+    print(gext.find_neighbours(181, 240, 60, 60))

--- a/parserscripts/interactions.py
+++ b/parserscripts/interactions.py
@@ -1,4 +1,4 @@
-## Making interactions.txt file from sorted BLAST outputs
+# Making interactions.txt file from sorted BLAST outputs
 
 import csv
 import json
@@ -7,10 +7,11 @@ import os
 
 
 def csv_to_list(csv_file, delimiter=","):
-    with open (csv_file, 'r') as csv_con:
+    with open(csv_file, 'r') as csv_con:
         reader = csv.reader(csv_con, delimiter=delimiter)
         return list(reader)
-    
+
+
 def convert_cells_to_floats(csv_cont):
     for row in range(len(csv_cont)):
         for cell in range(len(csv_cont[row])):
@@ -19,77 +20,77 @@ def convert_cells_to_floats(csv_cont):
             except ValueError:
                 pass
 
+
 def sort_by_column(csv_cont, col, reverse=False):
     header = csv_cont[0]
     body = csv_cont[1:]
-    if isinstance(col,str):
+    if isinstance(col, str):
         col_index = header.index(col)
     else:
         col_index = col
     body = sorted(body,
                   key=operator.itemgetter(col_index),
                   reverse=reverse)
-    body.insert(0,header)
+    body.insert(0, header)
     return body
 
+
 def print_csv(csv_content):
-    print (50*'-')
+    print(50 * '-')
     for row in csv_content:
-        row=[str(e) for e in row]
-        print ('\t' .join(row))
-    print (50*'_')
+        row = [str(e) for e in row]
+        print('\t'.join(row))
+    print(50 * '_')
+
 
 def write_csv(dest, csv_cont):
     with open(dest, 'w') as out_file:
-        writer= csv.writer(out_file, delimiter=',')
+        writer = csv.writer(out_file, delimiter=',')
         for row in csv_cont:
             writer.writerow(row)
-            
 
 
 elements = []
 phages = []
 edges = []
 
-
 for fn in os.listdir("output/sorted"):
     # made node for each bacteria and enter in elements
     bac_name = fn[7:16]
-    obj = { 
+    obj = {
         "group": 'nodes',
-        "data": {"id":bac_name},
+        "data": {"id": bac_name},
         "classes": 'bacteria'
     }
     elements.append(obj)
-    csv_cont = csv_to_list("output/sorted/"+fn)[1:]
+    csv_cont = csv_to_list("output/sorted/" + fn)[1:]
     for i in range(len(csv_cont)):
-        #only make phage node if it doesn't already exists
-        if (not(csv_cont[i][1] in phages)):
+        # only make phage node if it doesn't already exists
+        if csv_cont[i][1] not in phages:
             obj = {
                 "group": 'nodes',
-                "data": { "id": csv_cont[i][1]},
+                "data": {"id": csv_cont[i][1]},
                 "classes": 'phage'
             }
             elements.append(obj)
             phages.append(csv_cont[i][1])
-    
+
     for i in range(len(csv_cont)):
-        if (not(bac_name+"_to_"+csv_cont[i][1] in edges)):
-            obj ={
+        if not (bac_name + "_to_" + csv_cont[i][1] in edges):
+            obj = {
                 "group": 'edges',
-                "data": {"id": bac_name+"_to_"+csv_cont[i][1],
-                         "source": bac_name,
-                         "target": csv_cont[i][1]}
+                "data": {
+                    "id": bac_name + "_to_" + csv_cont[i][1],
+                    "source": bac_name,
+                    "target": csv_cont[i][1]
+                }
             }
             elements.append(obj)
-            edges.append(bac_name+"_to_"+csv_cont[i][1])
-            
-            
+            edges.append(bac_name + "_to_" + csv_cont[i][1])
 
-    # open each sorted file in output/sorted and get the phages, if phage is not phages list, add and create node, create edge
-    
-
-
+            # open each sorted file in output/sorted and get the
+            # phages, if phage is not phages list, add and create node,
+            # create edge
 
 """
 json_file = open("json.txt","w")
@@ -99,9 +100,8 @@ json_file.write("container: document.getElementById('cy')," +"\n")
 
 json_file.write("elements: [" + "\n")
 """
-with open("json.txt","w") as outfile:
-    json.dump(elements,outfile)
-    
-#for thing in elements:
+with open("json.txt", "w") as outfile:
+    json.dump(elements, outfile)
+
+# for thing in elements:
 #    json.write(thing)
-    

--- a/parserscripts/jointable.py
+++ b/parserscripts/jointable.py
@@ -1,89 +1,111 @@
 #!/usr/bin/python
 from __future__ import print_function
+
 import sqlite3
 
-def printDict(d):
-	for i in d:
-		print(i, d[i])
 
-def SQL_add(elem, name, columns, dbName):
-	conn = sqlite3.connect(dbName)
-	c = conn.cursor()
-	if isinstance(elem, list):
-		# It is assumed that the length of list and of columns will always match
-		q = "INSERT INTO " + str(name) + " (" + ",".join(columns) + ") VALUES ('"+ "','".join(elem) + "')"
-	else:
-		q = "INSERT INTO " + str(name) + columns + " VALUES " + elem
-	# print q
-	try:
-		c.execute(q)
-		conn.commit()
-	except sqlite3.IntegrityError:
-		print("Already In Database", elem)
-	c.close()
-	conn.close()
+def print_dict(d):
+    for i in d:
+        print(i, d[i])
 
 
-def SQL_search(elem, name, column, dbName):
-	conn = sqlite3.connect(dbName)
-	c = conn.cursor()
-	if isinstance(elem, list):
-		# It is assumed that the length of list and of columns will always match
-		q = "SELECT * FROM " + name + " " + " WHERE "
-		for i in range(0, len(elem)):
-			q += str(column[i]) + " = " + str(elem[i]) + " and "
-		q = q[:-5]
-	else:
-		q = "SELECT * FROM " + name + " " + " WHERE " + column + " = " + elem
-	# print q
-	c.execute(q)
-	r = c.fetchone()
-	c.close()
-	conn.close()
-	return r
-
-def readRepeatFile(filename):
-	fin = open(filename,'r')
-	out_dict = {}
-	flines = fin.readlines()
-	it = iter(flines)
-	tuple_list = zip(it,it)
-	for entry in tuple_list:
-		accessions =  entry[0][1:].replace('\n', '').split('|')
-		for acc in accessions:
-			out_dict[acc] = entry[1].replace('\n', '')
-	return out_dict
-
-def getIdAndAdd(elem, name, column, dbName):
-	item_id =  SQL_search(elem, name, column, dbName)
-	if(item_id is None):
-		SQL_add(elem, name, column, dbName)
-		item_id =  SQL_search(elem, name, column, dbName)
-	return item_id[0]
+def sql_add(elem, name, columns, db_name):
+    conn = sqlite3.connect(db_name)
+    c = conn.cursor()
+    if isinstance(elem, list):
+        # It is assumed that the length of list and of columns will
+        # always match
+        q = ("INSERT INTO " + str(name) + " (" + ",".join(columns)
+             + ") VALUES ('" + "','".join(elem) + "')")
+    else:
+        q = "INSERT INTO " + str(name) + columns + " VALUES " + elem
+    # print q
+    try:
+        c.execute(q)
+        conn.commit()
+    except sqlite3.IntegrityError:
+        print("Already In Database", elem)
+    c.close()
+    conn.close()
 
 
-def match_repeat_to_spacer(repeat_data, spacer_file_name, dbName):
-	spacer_file = open(spacer_file_name,'r').readlines()
-	it = iter(spacer_file)
-	tuple_list = zip(it,it)
-	for entry in tuple_list:
-		accessions =  entry[0][1:].replace('\n', '').split('|')
-		sequence = entry[1].replace('\n', '')
-		#print entry[1]
-		for acc in accessions:
-			acc_match = "_".join(acc.split("_")[:-1])
-			spacer_id =  getIdAndAdd("('"+sequence+"')", 'Spacer', '(SpacerSequence)', dbName)
-			repeat_id =  getIdAndAdd("('"+repeat_data[acc_match]+"')", 'Repeat', '(RepeatSequence)', dbName)
-			try:
-				match = repeat_data[acc_match]
-				acc
-			except KeyError:
-				print("Error: Wrong Accession code")
-			getIdAndAdd([str(spacer_id),str(repeat_id)], 'SpacerRepeatPair', ['SpacerID', 'RepeatID'], dbName)
+def sql_search(elem, name, column, db_name):
+    conn = sqlite3.connect(db_name)
+    c = conn.cursor()
+    if isinstance(elem, list):
+        # It is assumed that the length of list and of columns will
+        # always match
+        q = "SELECT * FROM " + name + " " + " WHERE "
+        for i in range(0, len(elem)):
+            q += str(column[i]) + " = " + str(elem[i]) + " and "
+        q = q[:-5]
+    else:
+        q = "SELECT * FROM " + name + " " + " WHERE " + column + " = " + elem
+    # print q
+    c.execute(q)
+    r = c.fetchone()
+    c.close()
+    conn.close()
+    return r
 
 
-spacerFile = 'data/spacerdatabase.txt'
-repeatFile = 'data/DRdatabase.txt'
-dbName = 'crispr.sqlite'
-repeat_dict = readRepeatFile(repeatFile)
-match_repeat_to_spacer(repeat_dict, spacerFile, dbName)
+def read_repeat_file(filename):
+    fin = open(filename, 'r')
+    out_dict = {}
+    flines = fin.readlines()
+    it = iter(flines)
+    tuple_list = zip(it, it)
+    for entry in tuple_list:
+        accessions = entry[0][1:].replace('\n', '').split('|')
+        for acc in accessions:
+            out_dict[acc] = entry[1].replace('\n', '')
+    return out_dict
+
+
+def get_id_and_add(elem, name, column, db_name):
+    item_id = sql_search(elem, name, column, db_name)
+    if item_id is None:
+        sql_add(elem, name, column, db_name)
+        item_id = sql_search(elem, name, column, db_name)
+    return item_id[0]
+
+
+def match_repeat_to_spacer(repeat_data, spacer_file_name, db_name):
+    spacer_file = open(spacer_file_name, 'r').readlines()
+    it = iter(spacer_file)
+    tuple_list = zip(it, it)
+    for entry in tuple_list:
+        accessions = entry[0][1:].replace('\n', '').split('|')
+        sequence = entry[1].replace('\n', '')
+        # print entry[1]
+        for acc in accessions:
+            acc_match = "_".join(acc.split("_")[:-1])
+            spacer_id = get_id_and_add(
+                "('" + sequence + "')",
+                'Spacer',
+                '(SpacerSequence)',
+                db_name
+            )
+            repeat_id = get_id_and_add(
+                "('" + repeat_data[acc_match] + "')",
+                'Repeat',
+                '(RepeatSequence)',
+                db_name
+            )
+            try:
+                match = repeat_data[acc_match]
+            except KeyError:
+                print("Error: Wrong Accession code")
+            get_id_and_add(
+                [str(spacer_id), str(repeat_id)],
+                'SpacerRepeatPair',
+                ['SpacerID', 'RepeatID'],
+                db_name
+            )
+
+
+spacer_file = 'data/spacerdatabase.txt'
+repeat_file = 'data/DRdatabase.txt'
+db_name = 'crispr.sqlite'
+repeat_dict = read_repeat_file(repeat_file)
+match_repeat_to_spacer(repeat_dict, spacer_file, db_name)

--- a/parserscripts/jointable.py
+++ b/parserscripts/jointable.py
@@ -50,9 +50,9 @@ def sql_search(elem, name, column, db_name):
 
 
 def read_repeat_file(filename):
-    fin = open(filename, 'r')
     out_dict = {}
-    flines = fin.readlines()
+    with open(filename, 'r') as fin:
+        flines = fin.readlines()
     it = iter(flines)
     tuple_list = zip(it, it)
     for entry in tuple_list:

--- a/parserscripts/orderByExpect.py
+++ b/parserscripts/orderByExpect.py
@@ -4,10 +4,11 @@ import os
 
 
 def csv_to_list(csv_file, delimiter=","):
-    with open (csv_file, 'r') as csv_con:
+    with open(csv_file, 'r') as csv_con:
         reader = csv.reader(csv_con, delimiter=delimiter)
         return list(reader)
-    
+
+
 def convert_cells_to_floats(csv_cont):
     for row in range(len(csv_cont)):
         for cell in range(len(csv_cont[row])):
@@ -16,37 +17,39 @@ def convert_cells_to_floats(csv_cont):
             except ValueError:
                 pass
 
+
 def sort_by_column(csv_cont, col, reverse=False):
     header = csv_cont[0]
     body = csv_cont[1:]
-    if isinstance(col,str):
+    if isinstance(col, str):
         col_index = header.index(col)
     else:
         col_index = col
     body = sorted(body,
                   key=operator.itemgetter(col_index),
                   reverse=reverse)
-    body.insert(0,header)
+    body.insert(0, header)
     return body
 
+
 def print_csv(csv_content):
-    print (50*'-')
+    print(50 * '-')
     for row in csv_content:
-        row=[str(e) for e in row]
-        print ('\t' .join(row))
-    print (50*'_')
+        row = [str(e) for e in row]
+        print('\t'.join(row))
+    print(50 * '_')
+
 
 def write_csv(dest, csv_cont):
     with open(dest, 'w') as out_file:
-        writer= csv.writer(out_file, delimiter=',')
+        writer = csv.writer(out_file, delimiter=',')
         for row in csv_cont:
             writer.writerow(row)
-            
+
 
 for fn in os.listdir("output/"):
-    csv_cont = csv_to_list('output/'+fn)
+    csv_cont = csv_to_list('output/' + fn)
     convert_cells_to_floats(csv_cont)
     csv_sorted = sort_by_column(csv_cont, "Expect")
-    write_csv("output/sorted/"+"sorted."+fn, csv_sorted)
-    #print_csv(csv_sorted)
-    
+    write_csv("output/sorted/" + "sorted." + fn, csv_sorted)
+    # print_csv(csv_sorted)

--- a/parserscripts/organism_name_update.py
+++ b/parserscripts/organism_name_update.py
@@ -16,32 +16,31 @@ DEPENDENCIES:
 Biopython
 """
 
+import sqlite3
 import sys
+
 from Bio import Entrez
 from Bio.SeqIO import parse
-import sqlite3
 
 sqlite_file = sys.argv[2]
-
 
 conn = sqlite3.connect(sqlite_file)
 conn.row_factory = lambda cursor, row: row[0]
 c = conn.cursor()
 
-
-#define email for entrez login
-db           = "nuccore"
+# define email for entrez login
+db = "nuccore"
 Entrez.email = sys.argv[1]
 
 
-
 def missing_names(sqlite_file):
-	'''
-	Check for and return accession numbers in Organism table that don't have names
-	'''
-	c.execute("SELECT  Accession FROM Organism WHERE OrganismName IS NULL")
-	id_list = c.fetchall()
-	return id_list
+    """
+    Check for and return accession numbers in Organism table that don't
+    have names
+    """
+    c.execute("SELECT  Accession FROM Organism WHERE OrganismName IS NULL")
+    id_list = c.fetchall()
+    return id_list
 
 
 def fetch_names(id_list):
@@ -50,10 +49,11 @@ def fetch_names(id_list):
     # Doing 100 by 100 to make sure requests to NCBI are not too big
     for i in range(0, len(id_list), 100):
         j = i + 100
-        if (j >= len(id_list)):
+        if j >= len(id_list):
             j = len(id_list)
 
-        sys.stderr.write("Fetching entries from %s to %s from GenBank\n" % (i, j))
+        sys.stderr.write(
+            "Fetching entries from %s to %s from GenBank\n" % (i, j))
         sys.stderr.flush()
         result_handle = Entrez.efetch(db=db, rettype="gb", id=id_list[i:j])
 
@@ -64,9 +64,11 @@ def fetch_names(id_list):
 
     return organism_names
 
+
 def insert_names(organism_names):
     for key in organism_names:
-        c.execute('UPDATE Organism SET OrganismName=? WHERE Accession=?', [organism_names[key], key])
+        c.execute('UPDATE Organism SET OrganismName=? WHERE Accession=?',
+                  [organism_names[key], key])
         print(key + ': ' + organism_names[key])
 
 
@@ -74,8 +76,5 @@ id_list = missing_names(sqlite_file)
 organism_names = fetch_names(id_list)
 insert_names(organism_names)
 
-
 conn.commit()
 conn.close()
-
-

--- a/parserscripts/parsers/find_accession.py
+++ b/parserscripts/parsers/find_accession.py
@@ -2,9 +2,9 @@ import csv
 
 
 class PhageFinder:
-    PHAGE_NAME=0
-    CLUSTER=1
-    EXIST_IN_GENBANK=4
+    PHAGE_NAME = 0
+    CLUSTER = 1
+    EXIST_IN_GENBANK = 4
     ACCESSION = 5
 
     def __init__(self, infile, **kwargs):
@@ -12,11 +12,11 @@ class PhageFinder:
         blast_file = open(infile, 'r')
         self.reader = csv.reader(blast_file, dialect=csv.excel_tab)
 
-    def findByPhage(self, phage, cluster):
+    def find_by_phage(self, phage, cluster):
         for row in self.reader:
-            #check if phage exists
+            # check if phage exists
             if phage in row[self.PHAGE_NAME] and cluster in row[self.CLUSTER]:
-                #check if exists in genbank
+                # check if exists in genbank
                 if 'True' in row[self.EXIST_IN_GENBANK]:
                     return row[self.ACCESSION]
         return -1

--- a/parserscripts/parsers/genome_extractor.py
+++ b/parserscripts/parsers/genome_extractor.py
@@ -1,40 +1,41 @@
 import csv
 
-''' 
-@author:         Nigesh Shakya(neaGaze)
-@timestamp:      06/08/2016 @ 12:54am (UTC)
-    
-The Class file that examines the file downloaded via prefetch (see #2), and returns a string corresponding to the genome starting n bases before startPosition and carrying on to m bases after endPosition. If either n or m are not provided, default them to 100.
-This patch pertains to issue #3 in the github wiki (https://github.com/goyalsid/phageParser/issues/3)
-'''
+
 class GenomeExtractor:
+    """
+    @author:         Nigesh Shakya(neaGaze)
+    @timestamp:      06/08/2016 @ 12:54am (UTC)
+
+    The Class file that examines the file downloaded via prefetch (see #2),
+    and returns a string corresponding to the genome starting n bases
+    before startPosition and carrying on to m bases after endPosition. If
+    either n or m are not provided, default them to 100.
+    This patch pertains to issue #3 in the github wiki
+    (https://github.com/goyalsid/phageParser/issues/3)
+    """
 
     def __init__(self, infile, **kwargs):
         blast_file = open(infile, 'r')
         self.reader = csv.reader(blast_file, dialect=csv.excel_tab)
-        pass
 
-    '''  Genome Extractor '''
-    def findNeighbours(self, startPosition, endPosition, n=100, m=100):
-        count = 0
-        hasDataFound = False
-        matchedGene = ""
+    def find_neighbours(self, start_position, end_position, n=100, m=100):
+        """ Genome Extractor """
+        has_data_found = False
+        matched_gene = ""
         for row in self.reader:
 
             if row[0] == "//":
                 break
 
-            if row[0].startswith("ORIGIN"): 
-                hasDataFound = True
+            if row[0].startswith("ORIGIN"):
+                has_data_found = True
                 continue
 
-            if hasDataFound:
-                rowVals = row[0].split()
-                pos = int(rowVals[0])
-                if pos >= startPosition -n and pos < endPosition + m:
-                    matchedGene += " ".join(rowVals)
-                    matchedGene += "\n"
-                     
-        return matchedGene
+            if has_data_found:
+                row_vals = row[0].split()
+                pos = int(row_vals[0])
+                if start_position - n <= pos < end_position + m:
+                    matched_gene += " ".join(row_vals)
+                    matched_gene += "\n"
 
-
+        return matched_gene

--- a/parserscripts/pfam_db.py
+++ b/parserscripts/pfam_db.py
@@ -108,8 +108,8 @@ def main():
     cds = extract_cds(file_path)
 
     for i, translation in enumerate(translations):
-        print("Getting translation " + str(i + 1) + "/" + str(
-            len(translations)) + "...")
+        print("Getting translation " + str(i + 1) + "/"
+              + str(len(translations)) + "...")
         url = get_translation_url(translation)
         result = get_values(url)
 

--- a/parserscripts/pfam_db.py
+++ b/parserscripts/pfam_db.py
@@ -1,30 +1,33 @@
-'''
-pfam_db.py extracts and submits the translations from a GenBank input file (such as data/Genbank_example.txt) 
-to PFAM, before writing results to a CSV file in the same directory.
+"""
+pfam_db.py extracts and submits the translations from a GenBank input
+file (such as data/Genbank_example.txt) to PFAM, before writing results
+to a CSV file in the same directory.
 
 Usage:
-python pfam_db.py <infile> 
+python pfam_db.py <infile>
 
 Ref - PR #73
-'''
+"""
 
-import re
-import requests
-from xml.etree import ElementTree
-import time
 import csv
 import os
+import re
 import sys
+import time
+from xml.etree import ElementTree
 
-filePath = str(sys.argv[1])
-filePathWithoutExt = os.path.splitext(filePath)[0]
+import requests
 
-def extractCDS(file):
+file_path = str(sys.argv[1])
+file_path_without_ext = os.path.splitext(file_path)[0]
+
+
+def extract_cds(file):
     cds = []
 
-    f = open(file, 'r')
-    fileText = f.read()
-    m = re.finditer('CDS\s{13}(?P<CDS>\S*)', fileText)
+    with open(file, 'r') as f:
+        file_text = f.read()
+    m = re.finditer('CDS\s{13}(?P<CDS>\S*)', file_text)
 
     for reg in m:
         element = reg.group('CDS')
@@ -33,12 +36,17 @@ def extractCDS(file):
 
     return cds
 
-def extractTranslations(file):
+
+def extract_translations(file):
     translations = []
 
-    f = open(file, 'r')
-    fileText = f.read()
-    m = re.finditer('/translation="(?P<translation>[\w\n ]+)"', fileText, re.MULTILINE)
+    with open(file, 'r') as f:
+        file_text = f.read()
+    m = re.finditer(
+        '/translation="(?P<translation>[\w\n ]+)"',
+        file_text,
+        re.MULTILINE
+    )
 
     for reg in m:
         translation = reg.group('translation')
@@ -48,17 +56,19 @@ def extractTranslations(file):
 
     return translations
 
-def getTranslationURL(translation):
+
+def get_translation_url(translation):
     url = "http://pfam.xfam.org/search/sequence"
     data = {'seq': translation, 'output': 'xml'}
 
-    response = requests.get(url, data = data)
+    response = requests.get(url, data=data)
 
     tree = ElementTree.fromstring(response.content)
 
     return tree[0][1].text
 
-def getValues(url):
+
+def get_values(url):
     sleep_time = 1
     tries = 60
     xml = ""
@@ -82,7 +92,6 @@ def getValues(url):
         print("Reached max tries without response.")
         return
 
-
     try:
         tree = ElementTree.fromstring(xml)
 
@@ -93,26 +102,29 @@ def getValues(url):
 
     return result
 
+
 def main():
-    translations = extractTranslations(filePath)
-    cds = extractCDS(filePath)
+    translations = extract_translations(file_path)
+    cds = extract_cds(file_path)
 
     for i, translation in enumerate(translations):
-        print("Getting translation " + str(i + 1) + "/" + str(len(translations)) + "...")
-        url = getTranslationURL(translation)
-        result = getValues(url)
+        print("Getting translation " + str(i + 1) + "/" + str(
+            len(translations)) + "...")
+        url = get_translation_url(translation)
+        result = get_values(url)
 
-        for indexRow, row in enumerate(result):
+        for index_row, row in enumerate(result):
             row["translation_number"] = i + 1
             row["cds"] = cds[i]
-            if i == 0 and indexRow == 0:
-                with open(filePathWithoutExt + '.csv', 'w') as f:
+            if i == 0 and index_row == 0:
+                with open(file_path_without_ext + '.csv', 'w') as f:
                     w = csv.DictWriter(f, row.keys())
                     w.writeheader()
 
-            with open(filePathWithoutExt + '.csv', 'a') as f:
+            with open(file_path_without_ext + '.csv', 'a') as f:
                 w = csv.DictWriter(f, row.keys())
                 w.writerow(row)
+
 
 if __name__ == "__main__":
     main()

--- a/parserscripts/phage.py
+++ b/parserscripts/phage.py
@@ -2,7 +2,7 @@ import re
 
 
 class Phage:
-    supported_databases = {
+    SUPPORTED_DATABASES = {
         # European Nucleotide Archive phage database
         "ENA": r"^gi\|[0-9]+\|ref\|([^\|]+)\|\ ([^,]+)[^$]*$",
 
@@ -21,7 +21,7 @@ class Phage:
         self._parse_phage(raw_text, phage_finder)
 
     def _parse_phage(self, raw_text, phage_finder):
-        for db, regex in Phage.supported_databases.items():
+        for db, regex in Phage.SUPPORTED_DATABASES.items():
             match = re.search(regex, raw_text)
             if match is not None:
                 if db is not "AD":

--- a/parserscripts/phage.py
+++ b/parserscripts/phage.py
@@ -1,36 +1,36 @@
 import re
 
+
 class Phage:
-  supported_databases = {
-    # European Nucleotide Archive phage database
-    "ENA": r"^gi\|[0-9]+\|ref\|([^\|]+)\|\ ([^,]+)[^$]*$",
+    supported_databases = {
+        # European Nucleotide Archive phage database
+        "ENA": r"^gi\|[0-9]+\|ref\|([^\|]+)\|\ ([^,]+)[^$]*$",
 
-    # National Center for Biotechnology Information phage database
-    "NCBI": r"^ENA\|([^\|]+)\|[^\ ]+\ ([^,]+)[^$]*$",
+        # National Center for Biotechnology Information phage database
+        "NCBI": r"^ENA\|([^\|]+)\|[^\ ]+\ ([^,]+)[^$]*$",
 
-    # Actinobacteriophage Database
-    "AD": r"^([^\ ]+)\ [^,]*,[^,]*,\ Cluster\ ([^$]+)$"
-  }
-  
+        # Actinobacteriophage Database
+        "AD": r"^([^\ ]+)\ [^,]*,[^,]*,\ Cluster\ ([^$]+)$"
+    }
 
-  def __init__(self, raw_text, phage_finder):
-    self.raw = raw_text.strip()
-    self.refseq = None
-    self.name = None
-    self.db = None
-    self._parsePhage(raw_text, phage_finder)
+    def __init__(self, raw_text, phage_finder):
+        self.raw = raw_text.strip()
+        self.refseq = None
+        self.name = None
+        self.db = None
+        self._parse_phage(raw_text, phage_finder)
 
-
-  def _parsePhage(self, raw_text, phage_finder):
-    for db, regex in Phage.supported_databases.items():
-      match = re.search(regex, raw_text)
-      if match is not None:
-        if db is not "AD":
-          self.name = match.group(2)
-          self.refseq = match.group(1)
-        else:
-          short_name = match.group(1)
-          cluster = match.group(2)
-          self.name = "Mycobacteriophage " + short_name
-          self.refseq = phage_finder.findByPhage(short_name, cluster)
-        self.db = db
+    def _parse_phage(self, raw_text, phage_finder):
+        for db, regex in Phage.supported_databases.items():
+            match = re.search(regex, raw_text)
+            if match is not None:
+                if db is not "AD":
+                    self.name = match.group(2)
+                    self.refseq = match.group(1)
+                else:
+                    short_name = match.group(1)
+                    cluster = match.group(2)
+                    self.name = "Mycobacteriophage " + short_name
+                    self.refseq = phage_finder.find_by_phage(short_name,
+                                                             cluster)
+                self.db = db

--- a/parserscripts/test_phage.py
+++ b/parserscripts/test_phage.py
@@ -12,19 +12,25 @@ def phage_finder():
 @pytest.mark.parametrize(
     'input, refseq, name',
     [
-        ("ENA|AP013478|AP013478.1 Uncultured Mediterranean phage uvMED DNA, complete",
-         "AP013478", "Uncultured Mediterranean phage uvMED DNA"),
-        ("gi|526118413|ref|NC_021856.1| Bacillus phage phiNIT1 DNA, complete genome",
-         "NC_021856.1", "Bacillus phage phiNIT1 DNA"),
-        ("JoeDirt Final Sequence, 74914 bp including 10 bp 3' overhang (TCGAACGGCC), Cluster L1",
-         "JF704108", "Mycobacteriophage JoeDirt"),
+        ("ENA|AP013478|AP013478.1 Uncultured Mediterranean phage uvMED "
+         "DNA, complete",
+         "AP013478",
+         "Uncultured Mediterranean phage uvMED DNA"),
+        ("gi|526118413|ref|NC_021856.1| Bacillus phage phiNIT1 DNA, "
+         "complete genome",
+         "NC_021856.1",
+         "Bacillus phage phiNIT1 DNA"),
+        ("JoeDirt Final Sequence, 74914 bp including 10 bp 3' overhang "
+         "(TCGAACGGCC), Cluster L1",
+         "JF704108",
+         "Mycobacteriophage JoeDirt"),
     ], ids=[
         'ena',
         'ncbi',
         'ad',
     ]
 )
-def test_phage_finder(phage_finder, input, refseq, name):
-    result = Phage(input, phage_finder)
+def test_phage_finder(phage_finder, phage_input, refseq, name):
+    result = Phage(phage_input, phage_finder)
     assert refseq == result.refseq
     assert name == result.name

--- a/parserscripts/test_phage.py
+++ b/parserscripts/test_phage.py
@@ -10,7 +10,7 @@ def phage_finder():
 
 
 @pytest.mark.parametrize(
-    'input, refseq, name',
+    'phage_input, refseq, name',
     [
         ("ENA|AP013478|AP013478.1 Uncultured Mediterranean phage uvMED "
          "DNA, complete",

--- a/phageAPI/settings.py
+++ b/phageAPI/settings.py
@@ -132,9 +132,9 @@ STATICFILES_DIRS = [
 # Simplified static file serving.
 # https://warehouse.python.org/project/whitenoise/
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
-#Dynamic rest addon for drf
+# Dynamic rest addon for drf
 DYNAMIC_REST = {
-    'ENABLE_LINKS':True,
+    'ENABLE_LINKS': True,
     'PAGE_SIZE': 500,
     'ENABLE_HOST_RELATIVE_LINKS': True
 }

--- a/populate_casgenes.py
+++ b/populate_casgenes.py
@@ -1,24 +1,22 @@
+# !/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import os
 
 import numpy as np
 
-# !/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
+""""
 Created on Thu Jun  1 12:44:58 2017
 
 @author: madeleine
-"""
 
-'''
 Issue #160
 
 Author: Madeleine
 Usage:python3 populate_casgenes.py
 
 Populates CasProtein and OrganismCasPair tables
-
-'''
+"""
 
 # table of cas proteins from Makarova et al 2015
 casprofiles = "data/crispr_type.csv"

--- a/populate_casgenes.py
+++ b/populate_casgenes.py
@@ -1,5 +1,7 @@
 import os
+
 import numpy as np
+
 # !/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
@@ -18,7 +20,6 @@ Populates CasProtein and OrganismCasPair tables
 
 '''
 
-
 # table of cas proteins from Makarova et al 2015
 casprofiles = "data/crispr_type.csv"
 
@@ -29,13 +30,18 @@ with open(casprofiles, 'r', encoding='utf8') as f:
 def populate_cas():
     print("Populating CasProtein table...")
     for row in profiles:
-        profileID = row[0].decode('utf8')
+        profile_id = row[0].decode('utf8')
         function = row[2].decode('utf8')
         gene = row[3].decode('utf8')
         group = row[4].decode('utf8')
         type_spec = row[5].decode('utf8')
         casprotein, created = CasProtein.objects.get_or_create(
-            profileID=profileID, function=function, gene=gene, group=group, type_specificity=type_spec)
+            profileID=profile_id,
+            function=function,
+            gene=gene,
+            group=group,
+            type_specificity=type_spec
+        )
     print("Done.")
     return
 
@@ -44,12 +50,13 @@ def populate_organismcaspair():
     print("Populating OrganismCasPair table...")
     # these are files split by organism accession
     for fn in os.listdir("gbfiles/hmmeroutput"):
-        data = np.loadtxt("gbfiles/hmmeroutput/%s" %
-                          fn, dtype='S')  # HMMER output results
-        accid = fn.rsplit('.')[0]  # organism accession number
+        # HMMER output results
+        data = np.loadtxt("gbfiles/hmmeroutput/%s" % fn, dtype='S')
+        # organism accession number
+        accid = fn.rsplit('.')[0]
 
-        organismset = Organism.objects.filter(
-            accession=accid)  # retrieve organism from database
+        # retrieve organism from database
+        organismset = Organism.objects.filter(accession=accid)
 
         if not organismset.exists():
             print('Organism with accid %s not found in db' % accid)
@@ -58,7 +65,8 @@ def populate_organismcaspair():
         organism = organismset[0]
 
         querylist = []
-        for row in data:  # iterate over HMMER matches to cas protein profiles
+        # iterate over HMMER matches to cas protein profiles
+        for row in data:
             if not data[0].shape:
                 row = data
             query = row[2].decode('utf8')  # cds start and end
@@ -74,11 +82,12 @@ def populate_organismcaspair():
             # this is the cas protein FK for the field casprotein
             casprotein = casproteinset[0]
 
-            if query not in querylist:  # we only keep 1 match if there are multiple
+            if query not in querylist:
+                # we only keep 1 match if there are multiple
                 querylist.append(query)
 
-                # check if sequence is complemented - if yes, start will be >
-                # end
+                # check if sequence is complemented - if yes, start
+                # will be > end
                 if query[:10] == 'complement':
                     query = query[11:-1]
                 try:
@@ -88,23 +97,30 @@ def populate_organismcaspair():
                     start = int(start)
                     end = int(end)
                 except Exception as e:
-                    print('Error accession {} with query {} with profile {} for error {}'.format(
-                        organism.accession, query, target_match, e))
+                    print('Error accession {} with query {} with profile {} '
+                          'for error {}'.format(organism.accession,
+                                                query,
+                                                target_match,
+                                                e))
                     continue
                 evalue = float(evalue)
-                osrpair, created = OrganismCasProtein.objects.get_or_create(organism=organism,
-                                                                            casprotein=casprotein,
-                                                                            genomic_start=start,
-                                                                            genomic_end=end,
-                                                                            evalue=evalue)
+                osrpair, created = OrganismCasProtein.objects.get_or_create(
+                    organism=organism,
+                    casprotein=casprotein,
+                    genomic_start=start,
+                    genomic_end=end,
+                    evalue=evalue
+                )
     print("Done.")
     return
 
 
 if __name__ == '__main__':
     import django
+
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "phageAPI.settings")
     django.setup()
     from restapi.models import Organism, CasProtein, OrganismCasProtein
+
     populate_cas()
     populate_organismcaspair()

--- a/populate_selftargets.py
+++ b/populate_selftargets.py
@@ -1,10 +1,10 @@
-import os
-import numpy as np
-import json
 import glob
+import json
+import os
+
+
 # !/usr/bin/env python3
 # -*- coding: utf-8 -*-
-
 
 
 def main(blastdir):
@@ -14,12 +14,15 @@ def main(blastdir):
         accession = os.path.splitext(os.path.split(fn)[1])[0]
         q_org = Organism.objects.filter(accession=accession)
         if not q_org.exists():
-            print('Organism with accession {} is not in db but blast report exists'.format(
-                accession))
+            print('Organism with accession {} is not in db but blast '
+                  'report exists'.format(accession))
             continue
         org = q_org[0]
-        interval_loci = [(entry['genomic_start'], entry['genomic_end'])
-                         for entry in org.locus_set.all().values('genomic_start', 'genomic_end')]
+        interval_loci = [
+            (entry['genomic_start'], entry['genomic_end'])
+            for entry in org.locus_set.all().values('genomic_start',
+                                                    'genomic_end')
+        ]
         with open(fn, 'r') as f:
             try:
                 blastrec = json.loads(f.read())
@@ -28,28 +31,36 @@ def main(blastdir):
                 continue
         for res in blastrec['BlastOutput2']:
             query = res['report']['results']['bl2seq'][0]
-            spacerid=query['query_title']
+            spacerid = query['query_title']
             for hit in query['hits']:
                 for hsps in hit['hsps']:
                     start_h, end_h = hsps['hit_from'], hsps['hit_to']
-                    in_locus = any([start_h > start and end_h <
-                                    end for start, end in interval_loci])
+                    in_locus = any([start_h > start and end_h < end
+                                    for start, end in interval_loci])
                     if in_locus:
                         continue
                     q_spacer = Spacer.objects.filter(id=int(spacerid))
                     if not q_spacer.exists():
-                        print('Spacer with sequence {} for organism {} not found in db'.format(
-                            hsps['qseq'], org.accession))
+                        print('Spacer with sequence {} for organism {} '
+                              'not found in db'.format(hsps['qseq'],
+                                                       org.accession))
                         continue
                     spacer = q_spacer[0]
                     evalue = float(hsps['evalue'])
                     oselftarget, _ = OrganismSelfSpacer.objects.get_or_create(
-                        organism=org, spacer=spacer, evalue=evalue, genomic_start=start_h, genomic_end=end_h)
+                        organism=org,
+                        spacer=spacer,
+                        evalue=evalue,
+                        genomic_start=start_h,
+                        genomic_end=end_h
+                    )
 
 
 if __name__ == '__main__':
     import django
+
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "phageAPI.settings")
     django.setup()
     from restapi.models import Organism, OrganismSelfSpacer, Spacer
+
     main('gbfiles/blastoutput')

--- a/populate_selftargets.py
+++ b/populate_selftargets.py
@@ -1,10 +1,9 @@
+# !/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import glob
 import json
 import os
-
-
-# !/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 
 def main(blastdir):

--- a/restapi/models.py
+++ b/restapi/models.py
@@ -34,6 +34,7 @@ class Organism(models.Model):
     cas_proteins = models.ManyToManyField(
         CasProtein, through='OrganismCasProtein')
     self_spacers = models.ManyToManyField(Spacer, through='OrganismSelfSpacer')
+
     def __str__(self):
         return '{} with accession {}'.format(self.name, self.accession)
 
@@ -52,14 +53,22 @@ class Phage(models.Model):
 
 class LocusSpacerRepeat(models.Model):
     locus = models.ForeignKey(
-        Locus, on_delete=models.CASCADE, null=True, related_name='spacerrepeats')
+        Locus,
+        on_delete=models.CASCADE,
+        null=True,
+        related_name='spacerrepeats'
+    )
     spacer = models.ForeignKey('Spacer', on_delete=models.CASCADE, null=True)
     repeat = models.ForeignKey('Repeat', on_delete=models.CASCADE, null=True)
     order = models.PositiveIntegerField(default=0)
 
 
 class OrganismAntiCRISPR(models.Model):
-    organism = models.ForeignKey('Organism', on_delete=models.CASCADE, null=True)
+    organism = models.ForeignKey(
+        'Organism',
+        on_delete=models.CASCADE,
+        null=True
+    )
     antiCRISPR = models.ForeignKey(
         'AntiCRISPR', on_delete=models.CASCADE, null=True)
     genomic_start = models.PositiveIntegerField(default=0)
@@ -80,6 +89,7 @@ class PhageSpacer(models.Model):
     genomic_start = models.PositiveIntegerField(default=0)
     genomic_end = models.PositiveIntegerField(default=0)
 
+
 class OrganismSelfSpacer(models.Model):
     organism = models.ForeignKey(
         'Organism', on_delete=models.CASCADE, null=True)
@@ -88,6 +98,8 @@ class OrganismSelfSpacer(models.Model):
     genomic_start = models.PositiveIntegerField(default=0)
     genomic_end = models.PositiveIntegerField(default=0)
     evalue = models.FloatField(default=0)
+
+
 class OrganismCasProtein(models.Model):
     organism = models.ForeignKey(
         'Organism', on_delete=models.CASCADE, null=True)

--- a/restapi/serializers.py
+++ b/restapi/serializers.py
@@ -1,6 +1,19 @@
-from restapi.models import Spacer, Repeat, Organism, LocusSpacerRepeat, CasProtein, OrganismCasProtein, Locus, OrganismSelfSpacer
-from dynamic_rest.serializers import DynamicModelSerializer, DynamicRelationField
 from dynamic_rest.fields import DynamicComputedField
+from dynamic_rest.serializers import (
+    DynamicModelSerializer,
+    DynamicRelationField
+)
+
+from restapi.models import (
+    CasProtein,
+    Locus,
+    LocusSpacerRepeat,
+    Organism,
+    OrganismCasProtein,
+    OrganismSelfSpacer,
+    Spacer,
+    Repeat
+)
 
 
 class GetSequenceLength(DynamicComputedField):
@@ -24,6 +37,7 @@ class SpacerSerializer(SequenceSerializer):
         model = Spacer
         fields = ('id', 'sequence', 'length', 'sequence', 'loci', 'repeats')
         deferred_fields = ('loci', 'repeats')
+
     loci = DynamicRelationField('LocusSerializer', many=True, embed=True)
     repeats = DynamicRelationField('RepeatSerializer', many=True)
 
@@ -33,6 +47,7 @@ class RepeatSerializer(SequenceSerializer):
         model = Repeat
         fields = ('id', 'length', 'sequence', 'loci', 'spacers')
         deferred_fields = ('loci', 'spacers')
+
     loci = DynamicRelationField('LocusSerializer', many=True)
     spacers = DynamicRelationField('SpacerSerializer', many=True)
 
@@ -44,6 +59,7 @@ class OrganismSerializer(DynamicModelSerializer):
                   'loci')
         deferred_fields = ('cas_proteins',
                            'loci')
+
     loci = DynamicRelationField(
         'LocusSerializer', source='locus_set', embed=True, many=True)
     cas_proteins = DynamicRelationField('CasProteinSerializer', many=True)
@@ -54,18 +70,19 @@ class LSRSerializer(DynamicModelSerializer):
         model = LocusSpacerRepeat
         fields = ('id', 'locus', 'spacer', 'repeat',
                   'order')
+
     spacer = DynamicRelationField('SpacerSerializer')
     repeat = DynamicRelationField('RepeatSerializer')
     locus = DynamicRelationField('LocusSerializer')
 
 
 class LocusSerializer(DynamicModelSerializer):
-
     class Meta:
         model = Locus
         fields = ('id', 'organism', 'genomic_start', 'genomic_end',
                   'spacerrepeats', 'spacers', 'repeats')
         deferred_fields = ('spacerrepeats', 'spacers', 'repeats')
+
     organism = DynamicRelationField('OrganismSerializer')
     spacers = DynamicRelationField('SpacerSerializer', embed=True, many=True)
     repeats = DynamicRelationField('RepeatSerializer', embed=True, many=True)

--- a/restapi/views.py
+++ b/restapi/views.py
@@ -1,6 +1,25 @@
-from restapi.serializers import SpacerSerializer, RepeatSerializer, OrganismSerializer, LSRSerializer, OCSerializer, CasProteinSerializer, LocusSerializer, OSSSerializer
-from restapi.models import Spacer, Repeat, Organism, LocusSpacerRepeat, OrganismCasProtein, CasProtein, Locus, OrganismSelfSpacer
 from dynamic_rest.viewsets import DynamicModelViewSet
+
+from restapi.models import (
+    CasProtein,
+    Locus,
+    LocusSpacerRepeat,
+    Organism,
+    OrganismCasProtein,
+    OrganismSelfSpacer,
+    Repeat,
+    Spacer
+)
+from restapi.serializers import (
+    CasProteinSerializer,
+    LSRSerializer,
+    LocusSerializer,
+    OCSerializer,
+    OSSSerializer,
+    OrganismSerializer,
+    SpacerSerializer,
+    RepeatSerializer
+)
 
 
 class SpacerViewSet(DynamicModelViewSet):
@@ -53,7 +72,8 @@ class OCViewSet(DynamicModelViewSet):
 
 class OSSViewSet(DynamicModelViewSet):
     """
-    API endpoint that allows organism self targeting spacer pairs to be viewed or edited.
+    API endpoint that allows organism self targeting spacer pairs to be
+    viewed or edited.
     """
     queryset = OrganismSelfSpacer.objects.all()
     serializer_class = OSSSerializer
@@ -61,7 +81,8 @@ class OSSViewSet(DynamicModelViewSet):
 
 class LSRViewSet(DynamicModelViewSet):
     """
-    API endpoint that allows locus spacer repeat pairs to be viewed or edited.
+    API endpoint that allows locus spacer repeat pairs to be viewed or
+    edited.
     """
     queryset = LocusSpacerRepeat.objects.all()
     serializer_class = LSRSerializer

--- a/util/acc.py
+++ b/util/acc.py
@@ -5,9 +5,8 @@ def read_accession_file(f):
 
     This automatically skips blank lines and comments.
     """
-    for l in f:
-        l = l.strip()
-        if not l or l.startswith('#'):
+    for line in f:
+        line = line.strip()
+        if not line or line.startswith('#'):
             continue
-        yield l
-
+        yield line

--- a/util/prunedict.py
+++ b/util/prunedict.py
@@ -1,48 +1,48 @@
 import pickle
 
 
-def findincompleterecords(gendict):
-    incomplist = []
-    for locid in gendict:
-        locus = gendict[locid]
+def find_incomplete_records(gen_dict):
+    incomp_list = []
+    for loc_id in gen_dict:
+        locus = gen_dict[loc_id]
         if not set(locus.keys()) == {'Spacers', 'Start', 'RepeatSeq', 'Stop'}:
-            incomplist.append(locid)
-    return incomplist
+            incomp_list.append(loc_id)
+    return incomp_list
 
 
-def findsizeoffsets(gendict):
-    offsetlist = []
-    for locid in gendict:
-        locus = gendict[locid]
-        possize = int(locus['Stop']) - int(locus['Start'])
-        spacersize = sum(len(s) for s in locus['Spacers'].values())
-        repeatsize = len(locus['RepeatSeq']) * (len(locus['Spacers']) + 1)
-        sizediff = possize - spacersize - repeatsize
-        offsetlist.append((sizediff, locid))
-    return offsetlist
+def find_size_offsets(gen_dict):
+    offset_list = []
+    for loc_id in gen_dict:
+        locus = gen_dict[loc_id]
+        pos_size = int(locus['Stop']) - int(locus['Start'])
+        spacer_size = sum(len(s) for s in locus['Spacers'].values())
+        repeat_size = len(locus['RepeatSeq']) * (len(locus['Spacers']) + 1)
+        size_diff = pos_size - spacer_size - repeat_size
+        offset_list.append((size_diff, loc_id))
+    return offset_list
 
 
-def delkeys(dictionary, keylist):
-    for key in keylist:
+def del_keys(dictionary, key_list):
+    for key in key_list:
         if key in dictionary:
             del dictionary[key]
     return dictionary
 
 
-def prunedict(gendict):
+def prune_dict(gen_dict):
     # remove loci with incomplete fields
-    incomplist = findincompleterecords(gendict)
-    gendict = delkeys(gendict, incomplist)
+    incomp_list = find_incomplete_records(gen_dict)
+    gen_dict = del_keys(gen_dict, incomp_list)
     # remove loci with offsets greater than 0
-    offsetlist = findsizeoffsets(gendict)
-    locitodel = [x[1] for x in offsetlist if x[0] > 0]
-    gendict = delkeys(gendict, locitodel)
-    return gendict
+    offset_list = find_size_offsets(gen_dict)
+    locitodel = [x[1] for x in offset_list if x[0] > 0]
+    gen_dict = del_keys(gen_dict, locitodel)
+    return gen_dict
 
 
 if __name__ == '__main__':
     with open('gendict.pickle', 'rb') as f:
-        gendict = pickle.load(f)
-    gendict = prunedict(gendict)
+        gen_dict = pickle.load(f)
+    gen_dict = prune_dict(gen_dict)
     with open('gendictpruned.pickle', 'wb') as f:
-        pickle.dump(gendict, f, protocol=pickle.HIGHEST_PROTOCOL)
+        pickle.dump(gen_dict, f, protocol=pickle.HIGHEST_PROTOCOL)

--- a/util/prunedict.py
+++ b/util/prunedict.py
@@ -5,7 +5,7 @@ def find_incomplete_records(gen_dict):
     incomp_list = []
     for loc_id in gen_dict:
         locus = gen_dict[loc_id]
-        if not set(locus.keys()) == {'Spacers', 'Start', 'RepeatSeq', 'Stop'}:
+        if set(locus.keys()) != {'Spacers', 'Start', 'RepeatSeq', 'Stop'}:
             incomp_list.append(loc_id)
     return incomp_list
 


### PR DESCRIPTION
This PR fixes most of #191 but there are still a few lines > 79 characters and probably a few other minor things that I missed. Here is a summary of the changes:

* Fix typo: `succesfully` -> `successfully`
* PEP8 fixes:

    * Reformat (most) lines longer than 79 chars  …
    * Two blank lines above top-level definitions
    * Add proper spacing around operators/commas
    * Use `snake_case` for function/variable names
    * Comments start with `# `
    * Use triple double-quoted strings for docstrings
    * Remove redundant parentheses
    * Simplify chained comparisons
    * Group imports (stdlib, third-party, local)
    * Remove unused imports
    * Remove excess spaces
    * Use `with` statements to ensure closing of files
    * Simplify conditionals `while ... == True -> while ...`
    * Remove unused variables
    * Use dict literals instead of multiple statements
    * Use a def instead of assigning a name to a lambda
    * Remove excess blank lines from EOF

