### PR TITLE
Issue #278 Add wait-retry function

### DIFF
--- a/demos/Phaster.ipynb
+++ b/demos/Phaster.ipynb
@@ -16,9 +16,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 2,
    "metadata": {
     "collapsed": true
    },
@@ -45,16 +45,15 @@
     "from scipy.stats import poisson\n",
     "from io import StringIO\n",
     "import time\n",
+    "import tryagain # pip install tryagain\n",
+    "\n",
     "sns.set_palette(\"husl\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create dictionary of prophages found in bacteria that have active CRISPR systems (confirmed by experiments)\n",
@@ -65,18 +64,14 @@
     "    for line in f:\n",
     "        acc = line.rstrip()\n",
     "        #print(acc)\n",
-    "        apiurl = \"http://phaster.ca/phaster_api?acc={}\".format(acc) \n",
-    "        r=requests.get(apiurl)\n",
-    "        try:\n",
-    "            d=r.json()['summary']\n",
-    "        except ValueError:  # includes simplejson.decoder.JSONDecodeError\n",
-    "            # wait a delay and try again\n",
-    "            time.sleep(2)\n",
-    "            try:\n",
-    "                r=requests.get(apiurl)\n",
-    "                d=r.json()['summary']\n",
-    "            except ValueError:  # includes simplejson.decoder.JSONDecodeError\n",
-    "                print(\"Error acquiring results for accession %s\" %acc)\n",
+    "        apiurl = \"http://phaster.ca/phaster_api?acc={}\".format(acc)\n",
+    "        \n",
+    "        def apicall():\n",
+    "            return requests.get(apiurl).json()['summary']\n",
+    "        # try this api call for max 5 times with waiting time of 2s,4s,8s,16s,32s, print each failures for monitoring\n",
+    "        # https://pypi.org/project/tryagain/\n",
+    "        d=tryagain.call(apicall, wait=lambda n: 2 ** n, max_attempts=5, exceptions=(ValueError),\n",
+    "                      cleanup_hook=lambda: print(\"Error acquiring results for accession {}\".format(acc)))\n",
     "        if d.find('Totally 0') != -1:\n",
     "            prophages = False\n",
     "            num_prophages = 0\n",
@@ -92,9 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create dictionary of prophages found in bacteria that may not have active CRISPR systems\n",
@@ -135,9 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": 66,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -184,9 +175,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda env:django]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-django-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -198,7 +189,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add a funciton to retry failed API calls after waiting. This function is added into the third block of this notebook for now.